### PR TITLE
Adding IDictionary<string,object> to FastExpando

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -474,7 +474,7 @@ namespace Dapper
 
         }
 #if !CSHARP30
-        private class FastExpando : System.Dynamic.DynamicObject
+        private class FastExpando : System.Dynamic.DynamicObject, IDictionary<string, object>
         {
             IDictionary<string, object> data;
 
@@ -493,6 +493,109 @@ namespace Dapper
             {
                 return data.TryGetValue(binder.Name, out result);
             }
+
+            #region IDictionary<string,object> Members
+
+            void IDictionary<string, object>.Add(string key, object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            bool IDictionary<string, object>.ContainsKey(string key)
+            {
+                return data.ContainsKey(key);
+            }
+
+            ICollection<string> IDictionary<string, object>.Keys
+            {
+                get { return data.Keys; }
+            }
+
+            bool IDictionary<string, object>.Remove(string key)
+            {
+                throw new NotImplementedException();
+            }
+
+            bool IDictionary<string, object>.TryGetValue(string key, out object value)
+            {
+                return data.TryGetValue(key, out value);
+            }
+
+            ICollection<object> IDictionary<string, object>.Values
+            {
+                get { return data.Values; }
+            }
+
+            object IDictionary<string, object>.this[string key]
+            {
+                get
+                {
+                    return data[key];
+                }
+                set
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            #endregion
+
+            #region ICollection<KeyValuePair<string,object>> Members
+
+            void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            void ICollection<KeyValuePair<string, object>>.Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
+            {
+                return data.Contains(item);
+            }
+
+            void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+            {
+                data.CopyTo(array, arrayIndex);
+            }
+
+            int ICollection<KeyValuePair<string, object>>.Count
+            {
+                get { return data.Count; }
+            }
+
+            bool ICollection<KeyValuePair<string, object>>.IsReadOnly
+            {
+                get { return true; }
+            }
+
+            bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            #endregion
+
+            #region IEnumerable<KeyValuePair<string,object>> Members
+
+            IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+            {
+                return data.GetEnumerator();
+            }
+
+            #endregion
+
+            #region IEnumerable Members
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return data.GetEnumerator();
+            }
+
+            #endregion
         }
 
 


### PR DESCRIPTION
I have added the IDictionary interface to the FastExpando dynamic object to make it more easily serializable by most of the common JSON serializers.

Adding this doesn't effect the performance of FastExpando because it implements a read only mapping to the internal data field.
