### PR TITLE
Use StringComparison.Ordinal instead of StringComparison.InvariantCulture

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -518,7 +518,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                         for (pos = current + 1; pos < reader.FieldCount; pos++)
                         {
                             // some people like ID some id ... assuming case insensitive splits for now
-                            if (splitOn == "*" || string.Equals(reader.GetName(pos), currentSplit, StringComparison.InvariantCultureIgnoreCase))
+                            if (splitOn == "*" || string.Equals(reader.GetName(pos), currentSplit, StringComparison.OrdinalIgnoreCase))
                             {
                                 break;
                             }
@@ -1105,10 +1105,10 @@ IDataReader reader, int startBound = 0, int length = -1, bool returnNullIfFirstM
 
             var setters = (
                             from n in names
-                            let prop = properties.FirstOrDefault(p => string.Equals(p.Name, n, StringComparison.InvariantCulture)) // property case sensitive first
-                                  ?? properties.FirstOrDefault(p => string.Equals(p.Name, n, StringComparison.InvariantCultureIgnoreCase)) // property case insensitive second
-                            let field = prop != null ? null : (fields.FirstOrDefault(p => string.Equals(p.Name, n, StringComparison.InvariantCulture)) // field case sensitive third
-                                ?? fields.FirstOrDefault(p => string.Equals(p.Name, n, StringComparison.InvariantCultureIgnoreCase))) // field case insensitive fourth
+                            let prop = properties.FirstOrDefault(p => string.Equals(p.Name, n, StringComparison.Ordinal)) // property case sensitive first
+                                  ?? properties.FirstOrDefault(p => string.Equals(p.Name, n, StringComparison.OrdinalIgnoreCase)) // property case insensitive second
+                            let field = prop != null ? null : (fields.FirstOrDefault(p => string.Equals(p.Name, n, StringComparison.Ordinal)) // field case sensitive third
+                                ?? fields.FirstOrDefault(p => string.Equals(p.Name, n, StringComparison.OrdinalIgnoreCase))) // field case insensitive fourth
                             select new { Name = n, Property = prop, Field = field }
                           ).ToList();
 


### PR DESCRIPTION
Changed use of StringComparison.InvariantCulture and InvariantCultureIgnoreCase to Ordinal and OrdinalIgnoreCase respectively.

Reasoning: http://msdn.microsoft.com/en-us/library/ms973919.aspx
