### PR TITLE
Added NHibernate test

### DIFF
--- a/Tests/NHibernate/NHibernateHelper.cs
+++ b/Tests/NHibernate/NHibernateHelper.cs
@@ -25,9 +25,9 @@ namespace SqlMapper.NHibernate
             }
         }
 
-        public static ISession OpenSession()
+        public static IStatelessSession OpenSession()
         {
-            return SessionFactory.OpenSession();
+            return SessionFactory.OpenStatelessSession();
         }
     }
 }

--- a/Tests/PerformanceTests.cs
+++ b/Tests/PerformanceTests.cs
@@ -177,6 +177,9 @@ namespace SqlMapper
                 .Query<Post>()
                 .Where(p => p.Id == id).First(), "NHibernate LINQ");
 
+			var nhSession5 = NHibernateHelper.OpenSession();
+			tests.Add(id => nhSession5.Get<Post>(id), "NHibernate Session.Get");
+
 			// bltoolkit
 			var db1 = new DbManager(Program.GetOpenConnection());
 			tests.Add(id => db1.SetCommand("select * from Posts where Id = @id", db1.Parameter("id", id)).ExecuteList<Post>(), "BLToolkit");


### PR DESCRIPTION
I've added NHibernate tests which fetches object directly from session using Session.Get<>. Maybe it's somehow shortcutted in NH but it seems to be a bit faster than queries, but still far for what Dapper does. Also I've changed NHibernateHelper to create stateless session, because Dapper is not ORM in terms of change tracking, so let's put them in the same conditions.
