### PR TITLE
Add support for dictionaries/expandos to DynamicParameters + Refactoring

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1963,16 +1963,14 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
         /// construct a dynamic parameter bag
         /// </summary>
         public DynamicParameters() { }
+        
         /// <summary>
         /// construct a dynamic parameter bag
         /// </summary>
         /// <param name="template">can be an anonymous type of a DynamicParameters bag</param>
         public DynamicParameters(object template)
         {
-            if (template != null)
-            {
-                AddDynamicParams(template);
-            }
+            AddDynamicParams(template);
         }
 
         /// <summary>
@@ -1988,16 +1986,29 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
 #endif
 )
         {
-            object obj = param as object;
-
+            var obj = param as object;
             if (obj != null)
             {
                 var subDynamic = obj as DynamicParameters;
-
                 if (subDynamic == null)
                 {
-                    templates = templates ?? new List<object>();
-                    templates.Add(obj);
+                    var dictionary = obj as IEnumerable<KeyValuePair<string, object>>;
+                    if (dictionary == null)
+                    {
+                        templates = templates ?? new List<object>();
+                        templates.Add(obj);
+                    }
+                    else
+                    {
+                        foreach (var kvp in dictionary)
+                        {
+#if CSHARP30
+                            Add(kvp.Key, kvp.Value, null, null, null);
+#else
+                            Add(kvp.Key, kvp.Value);
+#endif
+                        }
+                    }
                 }
                 else
                 {

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -778,7 +778,7 @@ Order by p.Id";
             connection.Query<TestEnumClass>("select 'bla' as [EnumEnum]").First().EnumEnum.IsEqualTo(TestEnum.Bla);
         }
 
-        public void TestSupportForParamDictionary()
+        public void TestSupportForDynamicParameters()
         {
             var p = new DynamicParameters();
             p.Add("name", "bob");
@@ -788,7 +788,6 @@ Order by p.Id";
 
             p.Get<int>("age").IsEqualTo(11);
         }
-
 
         public void TestProcSupport()
         {
@@ -1248,6 +1247,36 @@ Order by p.Id";
             ((int)result.b).IsEqualTo(2);
             ((int)result.c).IsEqualTo(3);
             ((int)result.d).IsEqualTo(4);
+        }
+
+        public void TestAppendingADictionary()
+        {
+            var dictionary = new Dictionary<string, object>();
+            dictionary.Add("A", 1);
+            dictionary.Add("B", "two");
+
+            DynamicParameters p = new DynamicParameters();
+            p.AddDynamicParams(dictionary);
+
+            var result = connection.Query("select @A a, @B b", p).Single();
+
+            ((int)result.a).IsEqualTo(1);
+            ((string)result.b).IsEqualTo("two");
+        }
+
+        public void TestAppendingAnExpandoObject()
+        {
+            dynamic expando = new System.Dynamic.ExpandoObject();
+            expando.A = 1;
+            expando.B = "two";
+
+            DynamicParameters p = new DynamicParameters();
+            p.AddDynamicParams(expando);
+
+            var result = connection.Query("select @A a, @B b", p).Single();
+
+            ((int)result.a).IsEqualTo(1);
+            ((string)result.b).IsEqualTo("two");
         }
 
         public void TestAppendingAList()


### PR DESCRIPTION
This pull request contains 3 small changes:

9993204f89a20bf131ece28841bfbae75ebb554a

Minor refactoring of the type deserializer. I'm working on adding support for type coercions and this change simplified the IL gen code. I plan to submit a pull request for that work when I'm finished.

63062d96aeeb009e15ee176c73e8b34b1eb75e12

This is a simple change that supports associating a default transaction with a command. See the test cases for an example. I prefer this type of implicit transaction management to the explicit form that requires you to pass the (connection,transaction) pair everywhere. The change should be harmless and unblocks my particular scenario.

081799e678bc7b44d0daec9aac8c40ad53e4e6d3

I added support for dictionaries to the DynamicParameters class. I had a use case where I didn't have a concrete type (the source of the parameter values was dynamic, but I couldn't add a reference to Dapper and use IDynamicParameters directly).
