### PR TITLE
Fixed a NullReferenceException when merging DynamicParameters

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1978,7 +1978,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
         /// <summary>
         /// construct a dynamic parameter bag
         /// </summary>
-        /// <param name="template">can be an anonymous type of a DynamicParameters bag</param>
+        /// <param name="template">can be an anonymous type or a DynamicParameters bag</param>
         public DynamicParameters(object template)
         {
             if (template != null)
@@ -1989,7 +1989,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
 
         /// <summary>
         /// Append a whole object full of params to the dynamic
-        /// EG: AddParams(new {A = 1, B = 2}) // will add property A and B to the dynamic
+        /// EG: AddDynamicParams(new {A = 1, B = 2}) // will add property A and B to the dynamic
         /// </summary>
         /// <param name="param"></param>
         public void AddDynamicParams(
@@ -2023,6 +2023,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
 
                     if (subDynamic.templates != null)
                     {
+                        templates = templates ?? new List<object>();
                         foreach (var t in subDynamic.templates)
                         {
                             templates.Add(t);


### PR DESCRIPTION
This fixes an exception that is raised in the following scenario:

```
var p1 = new DynamicParameters();
var p2 = new DynamicParameters(new { a = 1 });

// NullReferenceException
p1.AddDynamicParams(p2);
```
