### PR TITLE
Adding some common used overloads for Query, Execute and QueryMultiple

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -516,6 +516,29 @@ namespace Dapper
             return Query<T>(cnn, sql, param, transaction, true, null, commandType);
         }
 
+        /// <summary>
+        /// Execute a command that returns multiple result sets, and access each in turn
+        /// </summary>
+        public static GridReader QueryMultiple(this IDbConnection cnn, string sql, object param, IDbTransaction transaction) 
+        {
+            return QueryMultiple(cnn, sql, param, transaction, null, null);
+        }
+
+        /// <summary>
+        /// Execute a command that returns multiple result sets, and access each in turn
+        /// </summary>
+        public static GridReader QueryMultiple(this IDbConnection cnn, string sql, object param, CommandType commandType) 
+        {
+            return QueryMultiple(cnn, sql, param, null, null, commandType);
+        }
+
+        /// <summary>
+        /// Execute a command that returns multiple result sets, and access each in turn
+        /// </summary>
+        public static GridReader QueryMultiple(this IDbConnection cnn, string sql, object param, IDbTransaction transaction, CommandType commandType)
+        {
+            return QueryMultiple(cnn, sql, param, transaction, null, commandType);
+        }
 #endif
         /// <summary>
         /// Execute parameterized SQL  


### PR DESCRIPTION
I find myself using this when working on older runtime versions:
.Execute("UPDATE foo ...", params, transaction, null, null)
Or
.Query<TObj>("spGetObj", id, null, true, null, CommandType.StoredProcedure)

I think that fundamentally, all those defaults trues and nulls, are a lack of usability for older runtime versions.
At least CommandType and Transaction are of greater use.

This ammount of overloads, introduce a lot of lines of code without greater biz logic, and could incur in maintenance nightmare.
To minimize this, these overloads could be enclosed on a region (again, no greater biz logic come from them).

There's an alternative to this approach, with default and named arguments (as is on "Normal" version), but this way we loose the language specification previous to VS2010.

As said on the start of SqlMapper.cs, "This is a compromise".
