### PR TITLE
Updated DynamicParameters to allow inheritance of the AddParameters

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2140,6 +2140,16 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
 
         void SqlMapper.IDynamicParameters.AddParameters(IDbCommand command, SqlMapper.Identity identity)
         {
+            AddParameters(command, identity);
+        }
+
+        /// <summary>
+        /// Add all the parameters needed to the command just before it executes
+        /// </summary>
+        /// <param name="command">The raw command prior to execution</param>
+        /// <param name="identity">Information about the query</param>
+        protected void AddParameters(IDbCommand command, SqlMapper.Identity identity)
+        {
             if (templates != null)
             {
                 foreach (var template in templates)


### PR DESCRIPTION
When using TVPs in Sql Server I'm usually passing in additional non TVP parameters to the proc. By making the DynamicParameters.AddParameters functionality inheritable, when DynamicParameters is subclassed adding handling for your TVP type, you can reuse the existing parameter.

The DynamicParameterWithIntTVP w/ the TestTVPWithAdditionalParams method show example usage.
