### PR TITLE
sql_variant support query parameters and SQL Server

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -318,7 +318,7 @@ namespace Dapper
             typeMap[typeof(Guid?)] = DbType.Guid;
             typeMap[typeof(DateTime?)] = DbType.DateTime;
             typeMap[typeof(DateTimeOffset?)] = DbType.DateTimeOffset;
-            typeMap[typeof (Object)] = DbType.Object;
+            typeMap[typeof(Object)] = DbType.Object;
         }
 
         private const string LinqBinary = "System.Data.Linq.Binary";


### PR DESCRIPTION
Added object mapping that would allow posting of sql_variants to via parameters without getting the "The member {0} of type {1} cannot be used as a parameter value" error.  Tested locally without issue.
