### PR TITLE
Added dynamic query like for CSharp30.

### DIFF
--- a/DapperTests NET35/Tests.cs
+++ b/DapperTests NET35/Tests.cs
@@ -23,5 +23,22 @@ namespace DapperTests_NET35
         { 
             public string Value { get; set; }
         }
+
+        public void TestDynamicSimulatedQuery() {
+            var rows = connection.Query("select 1 A, 2 B union all select 3, 4", null).ToList();
+
+            ((int)rows[0]["A"])
+                .IsEqualTo(1);
+
+            ((int)rows[0]["B"])
+                .IsEqualTo(2);
+
+            ((int)rows[1]["A"])
+                .IsEqualTo(3);
+
+            ((int)rows[1]["B"])
+                .IsEqualTo(4);
+        }
+
     }
 }


### PR DESCRIPTION
The behavior is simulated with a Dictionary<string,object>.

This commit solves this issue http://stackoverflow.com/questions/11195526/dapper-c-sharp-3-5-mapping-to-dictionarystring-object

I needed this feature also, for some queries that are generated at runtime, so the use of the generic type wasn't possible.
Before this feature I had to mix dapper and manual Ado.net Commands and Parameters.
