### PR TITLE
Fixed issue with incorrect generated ParamReader when it has indexing properties declared.

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1453,7 +1453,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
             il.Emit(OpCodes.Ldarg_0); // stack is now [command]
             il.EmitCall(OpCodes.Callvirt, typeof(IDbCommand).GetProperty("Parameters").GetGetMethod(), null); // stack is now [parameters]
 
-            IEnumerable<PropertyInfo> props = type.GetProperties().OrderBy(p => p.Name);
+            IEnumerable<PropertyInfo> props = type.GetProperties().Where(p => p.GetIndexParameters().Length == 0).OrderBy(p => p.Name);
             if (filterParams)
             {
                 props = FilterParameters(props, identity.sql);

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -1916,6 +1916,27 @@ Order by p.Id";
             item.D.Equals(true);
         }
 
+        public class ParameterWithIndexer
+        {
+            public int A { get; set; }
+            public virtual string this[string columnName]
+            {
+                get { return null; }
+                set { }
+            }
+        }
+
+        public void TestParameterWithIndexer()
+        {
+            connection.Execute(@"create proc #TestProcWithIndexer 
+	@A int
+as 
+begin
+	select @A
+end");
+            var item = connection.Query<int>("#TestProcWithIndexer", new ParameterWithIndexer(), commandType: CommandType.StoredProcedure).Single();
+        }
+
         class TransactedConnection : IDbConnection
         {
             IDbConnection _conn;


### PR DESCRIPTION
System.InvalidProgramException was unhandled by user code
  HResult=-2146233030
  Message=Common Language Runtime detected an invalid program.
  Source=Smackdown
  StackTrace:
       at ParamInfo0087c0ea-e179-4127-aa16-e4c0454cb2c0(IDbCommand , Object )
       at Dapper.SqlMapper.SetupCommand(IDbConnection cnn, IDbTransaction transaction, String sql, Action`2 paramReader, Object obj, Nullable`1 commandTimeout, Nullable`1 commandType) in c:\GitHub\dapper-dot-net\Dapper\SqlMapper.cs:line 1611
       at Dapper.SqlMapper.<QueryInternal>d__d`1.MoveNext() in c:\GitHub\dapper-dot-net\Dapper\SqlMapper.cs:line 808
       at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
       at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
       at Dapper.SqlMapper.Query[T](IDbConnection cnn, String sql, Object param, IDbTransaction transaction, Boolean buffered, Nullable`1 commandTimeout, Nullable`1 commandType) in c:\GitHub\dapper-dot-net\Dapper\SqlMapper.cs:line 767
       at SqlMapper.Tests.TestParameterWithIndexer() in c:\GitHub\dapper-dot-net\Tests\Tests.cs:line 1937
  InnerException: 
