### PR TITLE
Multi-Mapping issue with SplitOn

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1041,7 +1041,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
 
             Func<Type, int> nextSplit = type =>
             {
-                var currentSplit = splits[splitIndex];
+                var currentSplit = splits[splitIndex].Trim();
                 if (splits.Length > splitIndex + 1)
                 {
                     splitIndex++;

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -1103,6 +1103,25 @@ end");
 
         }
 
+        public void TestMultiMappingWithSplitOnSpaceBetweenCommas()
+        {
+            var sql = @"select 
+                        1 as PersonId, 'bob' as Name, 
+                        2 as AddressId, 'abc street' as Name, 1 as PersonId,
+                        3 as Id, 'fred' as Name
+                        ";
+            var personWithAddress = connection.Query<Person, Address, Extra, Tuple<Person, Address, Extra>>
+                (sql, (p, a, e) => Tuple.Create(p, a, e), splitOn: "AddressId, Id").First();
+
+            personWithAddress.Item1.PersonId.IsEqualTo(1);
+            personWithAddress.Item1.Name.IsEqualTo("bob");
+            personWithAddress.Item2.AddressId.IsEqualTo(2);
+            personWithAddress.Item2.Name.IsEqualTo("abc street");
+            personWithAddress.Item2.PersonId.IsEqualTo(1);
+            personWithAddress.Item3.Id.IsEqualTo(3);
+            personWithAddress.Item3.Name.IsEqualTo("fred");
+
+        }
 
         public void TestFastExpandoSupportsIDictionary()
         {


### PR DESCRIPTION
There was a small issue when SplinOn spaces between commas, for example:
splitOn: "AddressId, Id".
For more info see:
http://stackoverflow.com/questions/11042618/dapper-multi-mapping-issue

I have modified below line of code:
From: var currentSplit = splits[splitIndex];
To: var currentSplit = splits[splitIndex].Trim();

Also added a test called:
TestMultiMappingWithSplitOnSpaceBetweenCommas()
