### PR TITLE
Added a reader.Close() and reader=null to QueryInternal.

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -828,6 +828,8 @@ this IDbConnection cnn, string sql, dynamic param = null, IDbTransaction transac
                     {
                         yield return (T)func(reader);
                     }
+                    reader.Close();
+                    reader = null;
                 }
                 finally
                 {


### PR DESCRIPTION
This stops spurious log messages in Postgres, and stops intermittent aborted queries from what looks to be a race condition.  This has only been tested in Postgres.
