### PR TITLE
DapperRow.Count is now O(1), added type-safe reflection, added GetValue

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1585,7 +1585,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                         string[] names = new string[effectiveFieldCount];
                         for (int i = 0; i < effectiveFieldCount; i++)
                         {
-                            names[i] = reader.GetName(i + startBound);
+                            names[i] = r.GetName(i + startBound);
                         }
                         table = new DapperTable(names);
                     }


### PR DESCRIPTION
As discussed here: https://github.com/SamSaffron/dapper-dot-net/pull/58#issuecomment-9839262

Marc seemed ok by the suggested changes to DapperTable branch.
