### PR TITLE
Allows a class to have a reserved word as a column name.

### DIFF
--- a/Dapper.Contrib.Tests/Program.cs
+++ b/Dapper.Contrib.Tests/Program.cs
@@ -32,6 +32,7 @@ namespace Dapper.Contrib.Tests
                 connection.Open();
                 connection.Execute(@" create table Users (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, Age int not null) ");
                 connection.Execute(@" create table Automobiles (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null) ");
+                connection.Execute(@" create table Results (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, [Order] int not null) ");
             }
             Console.WriteLine("Created database");
         }

--- a/Dapper.Contrib.Tests/Tests.cs
+++ b/Dapper.Contrib.Tests/Tests.cs
@@ -33,6 +33,14 @@ namespace Dapper.Contrib.Tests
         public string Name { get; set; }
     }
 
+    [Table("Results")]
+    public class Result
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int Order { get; set; }
+    }
+
     public class Tests
     {
         private IDbConnection GetOpenConnection()
@@ -75,7 +83,7 @@ namespace Dapper.Contrib.Tests
         {
             using (var connection = GetOpenConnection())
             {
-                connection.Get<IUser>(3).IsNull();
+                connection.Get<User>(3).IsNull();
 
                 var id = connection.Insert(new User {Name = "Adam", Age = 10});
 
@@ -160,6 +168,18 @@ namespace Dapper.Contrib.Tests
                 if (connection.Query<int>(template.RawSql, template.Parameters).Single() != 1)
                     throw new Exception("Query failed");
             }
+        }
+
+        public void InsertFieldWithReservedName()
+        {
+            using (var conneciton = GetOpenConnection())
+            {
+                var id = conneciton.Insert(new Result() { Name = "Adam", Order = 1 });
+
+                var result = conneciton.Get<Result>(id);
+                result.Order.IsEqualTo(1);
+            }
+
         }
     }
 }

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -180,7 +180,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < allPropertiesExceptKey.Count(); i++)
             {
                 var property = allPropertiesExceptKey.ElementAt(i);
-				sbColumnList.Append(property.Name);
+				sbColumnList.AppendFormat("[{0}]", property.Name);
                 if (i < allPropertiesExceptKey.Count() - 1)
 					sbColumnList.Append(", ");
             }


### PR DESCRIPTION
Insert failed when a word such as order was used as a column name.
Added [] around the column name.

Also modified the test for InsertGetUpdate().  The first Get is now a
User instead of IUser.  There is an existing bug where using the interface
twice first on a null result and then on the real result causes the
reader to not be open when trying to map the type.
