### PR TITLE
Bug fix for "Invalid attempt to call MetaData when reader is closed"

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1524,7 +1524,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                         string[] names = new string[effectiveFieldCount];
                         for (int i = 0; i < effectiveFieldCount; i++)
                         {
-                            names[i] = reader.GetName(i + startBound);
+                            names[i] = r.GetName(i + startBound);
                         }
                         table = new DapperTable(names);
                     }


### PR DESCRIPTION
Would occasionally generate exception "Invalid attempt to call MetaData when reader is closed"
