### PR TITLE
Simple Composite Entity Mapping Support

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -2705,28 +2705,31 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                 var count = 0;
                 bool isString = value is IEnumerable<string>;
                 bool isDbString = value is IEnumerable<DbString>;
-                foreach (var item in list)
+                if (list != null)
                 {
-                    count++;
-                    var listParam = command.CreateParameter();
-                    listParam.ParameterName = namePrefix + count;
-                    if (isString)
+                    foreach (var item in list)
                     {
-                        listParam.Size = DbString.DefaultLength;
-                        if (item != null && ((string)item).Length > DbString.DefaultLength)
+                        count++;
+                        var listParam = command.CreateParameter();
+                        listParam.ParameterName = namePrefix + count;
+                        if (isString)
                         {
-                            listParam.Size = -1;
+                            listParam.Size = DbString.DefaultLength;
+                            if (item != null && ((string)item).Length > DbString.DefaultLength)
+                            {
+                                listParam.Size = -1;
+                            }
                         }
-                    }
-                    if (isDbString && item as DbString != null)
-                    {
-                        var str = item as DbString;
-                        str.AddParameter(command, listParam.ParameterName);
-                    }
-                    else
-                    {
-                        listParam.Value = item ?? DBNull.Value;
-                        command.Parameters.Add(listParam);
+                        if (isDbString && item as DbString != null)
+                        {
+                            var str = item as DbString;
+                            str.AddParameter(command, listParam.ParameterName);
+                        }
+                        else
+                        {
+                            listParam.Value = item ?? DBNull.Value;
+                            command.Parameters.Add(listParam);
+                        }
                     }
                 }
 


### PR DESCRIPTION
I've added support for Composite Entity Mapping. For reference, look at my test named TestCompositeEntity().

The idea is that to map the column names onto a simple entity graph. Using quoted column name identifiers (such as "Category.Name"), the mapper will get a property named "Category" and create it if necessary using the type's default ctor. It then maps the column onto the "Name" property of the "Category" instance.

This graph can be nested.

This was implemented primarily by modifying DefaultTypeMap and SimpleMemberMap to include the nested property graph detection code. A new property was added to IMemberMap to expose the nested property graph to IL generating method.

A new subroutine was added during IL generation to handle the nested property graph (recursively creates the necessary properties and pushes it onto the stack to the receive the value).

It references this: http://code.google.com/p/dapper-dot-net/issues/detail?id=126
