### PR TITLE
Rainbow: Ignore Id property when calling Table.Insert 

### DIFF
--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -54,6 +54,7 @@ namespace Dapper
             {
                 var o = (object)data;
                 List<string> paramNames = GetParamNames(o);
+                paramNames.Remove("Id");
 
                 string cols = string.Join(",", paramNames);
                 string cols_params = string.Join(",", paramNames.Select(p => "@" + p));


### PR DESCRIPTION
Id is being removed most places in Rainbow, but not on Table.Insert. I
changed this to make it consistent with SqlCompactTable.Insert and
Table.Update.
