### PR TITLE
Loose typing for primitive value queries

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2033,6 +2033,8 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                 {
                     il.Emit(OpCodes.Ldc_I4_0); // stack is now [typed-value][0]
                     il.Emit(OpCodes.Ceq); // stack is now [0 or 1]
+                    il.Emit(OpCodes.Ldc_I4_0); // stack is now [0 or 1][0]
+                    il.Emit(OpCodes.Ceq); // stack is now [0 or 1]
                 }
             }
             else

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -1732,6 +1732,12 @@ Order by p.Id";
             val.IsEqualTo(1);
         }
 
+        public void TestWrongBooleanResultGetsConverted()
+        {
+            var val = connection.Query<bool>("select 1").Single();
+            val.IsTrue();
+        }
+
         public void TestWrongNullablePrimitiveResultNullResultWorks()
         {
             connection.Execute(@"CREATE TABLE #TestNull(Id int)");


### PR DESCRIPTION
Dapper now does loose type conversions when mapping to object fields, but the same behaviour isn't applied to primitive queries, i.e. `Query<int>()`.  Having this functionality would be useful for cases where it's not very easy to force the database driver to give you the specific return type you want, such as when your application supports multiple database backends and one of them is... _uncooperative_.

I quickly pulled (most of) the code used when mapping object fields into the deserializer for primitive values for use in Data Explorer, and it hasn't blown up yet, but it probably needs a look-over. It'd be nice to get this integrated though; Marc had indicated that the difference in behaviour here was likely not expected.
