### PR TITLE
DapperRow dynamic invocation fails in Visual basic - fix

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1234,6 +1234,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                 if (fieldNameLookup.ContainsKey(name)) throw new InvalidOperationException("Field already exists: " + name);
                 int oldLen = fieldNames.Length;
                 Array.Resize(ref fieldNames, oldLen + 1); // yes, this is sub-optimal, but this is not the expected common case
+                fieldNames[oldLen] = name;
                 fieldNameLookup[name] = oldLen;
                 return oldLen;
             }


### PR DESCRIPTION
Without the added BindInvokeMember override the following fails when using dapper in Visual Basic:

Using conn = New SqlClient.SqlConnection("connectionstring")

   Dim data = conn.Query("SELECT 1 AS A, 2 AS B").SingleOrDefault() 

   Dim A = data.A 

End Using

With the following error message:
Public member 'A' on type 'DapperRow' not found.

I don't fully understand what's going on in the DapperRow/table logic, but this seems to work, and all c# tests still completes succesfully. 

( this is my first ever pull request, so I am sorry if I missed something obvious ) :-) 
