### PR TITLE
Changes to DapperRow to make it obey the semantics of IDictionary<>

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1296,6 +1296,19 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                 return callMethod;
             }
 
+            // Needed for Visual basic dynamic support
+            public override System.Dynamic.DynamicMetaObject BindInvokeMember(System.Dynamic.InvokeMemberBinder binder, System.Dynamic.DynamicMetaObject[] args)
+            {
+                var parameters = new System.Linq.Expressions.Expression[]
+                                     {
+                                         System.Linq.Expressions.Expression.Constant(binder.Name)
+                                     };
+
+                var callMethod = CallMethod(getValueMethod, parameters);
+
+                return callMethod;
+            }
+
             public override System.Dynamic.DynamicMetaObject BindSetMember(System.Dynamic.SetMemberBinder binder, System.Dynamic.DynamicMetaObject value)
             {
                 var parameters = new System.Linq.Expressions.Expression[]


### PR DESCRIPTION
Hi.

I modified DapperRow so that it obeys the semantics of IDictionary<>.

AFAICT there were two issues with current implementation of DapperRow:
1. Count is expected to be O(1) not O(n)
2. .Add should throw on duplicate key

In addition I made some bug fixes in how DBNull is handled and a fix regarding dynamic names.

I had applied KorsG pull request to this pull request as well because it made sense to me to support VB as well.
