### PR TITLE
Remove complex types from model for insert and update 

### DIFF
--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -129,7 +129,9 @@ namespace Dapper
                     paramNames = new List<string>();
                     foreach (var prop in o.GetType().GetProperties(BindingFlags.GetProperty | BindingFlags.Instance | BindingFlags.Public))
                     {
-                        paramNames.Add(prop.Name);
+                        //filters out complex types because those are not going to be inserted or updated directly
+                        if (IsSimpleType(prop.PropertyType))
+                            paramNames.Add(prop.Name);
                     }
                     paramNameCache[o.GetType()] = paramNames;
                 }
@@ -320,6 +322,31 @@ namespace Dapper
             return SqlMapper.QueryMultiple(connection, sql, param, transaction, commandTimeout, commandType);
         }
 
+        private static bool IsSimpleType(Type propertyType)
+        {
+            var simpleTypes = new List<Type>
+                                  {
+                                      typeof(byte),
+                                      typeof(sbyte),
+                                      typeof(short),
+                                      typeof(ushort),
+                                      typeof(int),
+                                      typeof(uint),
+                                      typeof(long),
+                                      typeof(ulong),
+                                      typeof(float),
+                                      typeof(double),
+                                      typeof(decimal),
+                                      typeof(bool),
+                                      typeof(string),
+                                      typeof(char),
+                                      typeof(Guid),
+                                      typeof(DateTime),
+                                      typeof(DateTimeOffset),
+                                      typeof(byte[])
+                                  };
+            return simpleTypes.Contains(propertyType);
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
Sam,

We have situations where we have 1 store with a list of products. 

public class Store {

//represents store table
 public int Id {get; set;}
 public string StoreName {get; set;}

//related table of products
 public List<Product> products {get; set;}
}

public class Product{
//represents product table
 public int Id {get; set;}
 public int StoreId {get; set;}
 public string ProductName {get; set;}
}

With models like this Rainbow builds up SQL for the list of Product when creating insert or update sql. Since the inserts or updates wouldn't ever work with complex types Query fails. 

We would need to create separate models for the Store for interacting with the database and for actually using the Store in the application. I understand that in some cases that would be a better setup but I think this code change makes it easier to simplify domain and database models.

Eric  
