### PR TITLE
SqlMap MultiMapImpl function's connection state need to be verified

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1001,11 +1001,14 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
             IDbCommand ownedCommand = null;
             IDataReader ownedReader = null;
 
+	    bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
                 if (reader == null)
                 {
                     ownedCommand = SetupCommand(cnn, transaction, sql, cinfo.ParamReader, (object)param, commandTimeout, commandType);
+                    if (wasClosed) cnn.Open();
+                    
                     ownedReader = ownedCommand.ExecuteReader();
                     reader = ownedReader;
                 }


### PR DESCRIPTION
When MultiMapImpl function is called, there is an exception showing a cloesed state of connection.
After trace the connection object, I think it can be fixed by checking connection state whether
it is closed or opened. 
