### PR TITLE
Added ColumnBind and ConstructorBind events to allow for non-trivial bindings

### DIFF
--- a/Tests/DapperTests.csproj
+++ b/Tests/DapperTests.csproj
@@ -244,7 +244,7 @@
       <Name>Dapper.Contrib</Name>
     </ProjectReference>
     <ProjectReference Include="..\Dapper\Dapper.csproj">
-      <Project>{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}</Project>
+      <Project>{daf737e1-05b5-4189-a5aa-dac6233b64d7}</Project>
       <Name>Dapper</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Implement functionality described in Issue 108 and at
http://stackoverflow.com/questions/11703600/dapper-column-number-rather-than-column-name/11704151#11704151

Supports arbitrary resolution of constructors and columns in the cases
where Dapper conventions aren't followed.  

May cause a slight
performance impact when events are bound as resolutions are cached. Should have very little impact if no handlers are bound to these events.
