### PR TITLE
Support for "ignoring Navigation Property"

### DIFF
--- a/Dapper.Rainbow/Dapper.Rainbow.csproj
+++ b/Dapper.Rainbow/Dapper.Rainbow.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Database.cs" />
+    <Compile Include="IgnorePropertyAttribute.cs" />
     <Compile Include="Snapshotter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlCompactDatabase.cs" />

--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -129,7 +129,12 @@ namespace Dapper
                     paramNames = new List<string>();
                     foreach (var prop in o.GetType().GetProperties(BindingFlags.GetProperty | BindingFlags.Instance | BindingFlags.Public))
                     {
-                        paramNames.Add(prop.Name);
+                        var attribs = prop.GetCustomAttributes(typeof(IgnorePropertyAttribute), true);
+                        var attr = attribs.FirstOrDefault() as IgnorePropertyAttribute;
+                        if (attr==null || (attr != null && !attr.Value))
+                        {
+                            paramNames.Add(prop.Name);
+                        }                        
                     }
                     paramNameCache[o.GetType()] = paramNames;
                 }

--- a/Dapper.Rainbow/IgnorePropertyAttribute.cs
+++ b/Dapper.Rainbow/IgnorePropertyAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Dapper
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    public class IgnorePropertyAttribute : Attribute
+    {
+        public IgnorePropertyAttribute(bool ignore)
+        {
+            Value = ignore;
+        }
+
+        public bool Value { get; set; }
+    }
+}


### PR DESCRIPTION
I have asked [this question in SO](http://stackoverflow.com/questions/15708246/how-to-insert-an-object-with-navigation-property-using-dapper-rainbow) and got no answer. I have Googled and SOed the issue but could not find any article that shows me how to do it. I am currently using NHibernate and my class' current structure is supported just fine. But it's not supported in Dapper. You may read my SO question for details. 

In the end I ended up with the following using the code in my pull request:

```
public class Product {
    public int Id {get;set;}
    public string Name {get;set;}
    [IgnoreProperty(true)]
    public ProductCategory Category {get;set;}
    public int CategoryId {get;set;} // I have to add this. I don't need this using NH
}
```

This works for what I need although I prefer that I can control the "ignoring of fields" by code and not by configuration (attribute) - which would be a different approach but this solution works fine for now.

Please let me know if this won't break the core Dapper behavior and objective. And, if this already exists and I missed the part that tells me how to do this, please point me in the right direction. If this does not exists yet, may I ask why this is not part of the Dapper core?
