### PR TITLE
Fix VS2010 solution and tests to be at least SQL Server 2008 compatible

### DIFF
--- a/Dapper.sln
+++ b/Dapper.sln
@@ -1,9 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper", "Dapper\Dapper.csproj", "{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DapperTests", "Tests\DapperTests.csproj", "{A2A80512-11F4-4028-A995-505463632C84}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DapperTests NET40", "Tests\DapperTests NET40.csproj", "{A2A80512-11F4-4028-A995-505463632C84}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper NET35", "Dapper NET35\Dapper NET35.csproj", "{B26305D8-3A89-4D68-A981-9BBF378B81FA}"
 EndProject
@@ -17,6 +15,23 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.SqlBuilder", "Dapper
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.Rainbow", "Dapper.Rainbow\Dapper.Rainbow.csproj", "{21BC6EA8-3D10-4CC9-A1B3-9FAD59F7D1BB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E043638B-9516-477C-A75A-254DD55D4113}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper NET40", "Dapper NET40\Dapper NET40.csproj", "{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper NET45", "Dapper NET45\Dapper NET45.csproj", "{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E757192C-9411-458D-8815-8DAB34E12D03}"
+	ProjectSection(SolutionItems) = preProject
+		dapper.nuspec = dapper.nuspec
+		License.txt = License.txt
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DapperTests NET45", "DapperTests NET45\DapperTests NET45.csproj", "{5A5183F5-B774-42C9-A992-0A9C85FBE770}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,16 +42,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|x86.ActiveCfg = Release|Any CPU
 		{A2A80512-11F4-4028-A995-505463632C84}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{A2A80512-11F4-4028-A995-505463632C84}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
 		{A2A80512-11F4-4028-A995-505463632C84}.Debug|Mixed Platforms.Build.0 = Debug|x86
@@ -107,6 +112,36 @@ Global
 		{21BC6EA8-3D10-4CC9-A1B3-9FAD59F7D1BB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{21BC6EA8-3D10-4CC9-A1B3-9FAD59F7D1BB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{21BC6EA8-3D10-4CC9-A1B3-9FAD59F7D1BB}.Release|x86.ActiveCfg = Release|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}.Release|x86.ActiveCfg = Release|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{0FFF5BC7-0A4B-4D87-835E-4FAD70937507}.Release|x86.ActiveCfg = Release|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{5A5183F5-B774-42C9-A992-0A9C85FBE770}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/DapperTests NET40.csproj
+++ b/Tests/DapperTests NET40.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SqlMapper</RootNamespace>
     <AssemblyName>Smackdown</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
@@ -241,9 +241,9 @@
     <Folder Include="Simple.Data\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Dapper NET45\Dapper NET45.csproj">
-      <Project>{0fff5bc7-0a4b-4d87-835e-4fad70937507}</Project>
-      <Name>Dapper NET45</Name>
+    <ProjectReference Include="..\Dapper NET40\Dapper NET40.csproj">
+      <Project>{DAF737E1-05B5-4189-A5AA-DAC6233B64D7}</Project>
+      <Name>Dapper NET40</Name>
     </ProjectReference>
     <ProjectReference Include="..\Dapper.Contrib\Dapper.Contrib.csproj">
       <Project>{C2FC4DF5-C8D1-4EA8-8E0C-85A3793EB0BB}</Project>

--- a/Tests/EntityFramework/Model.Designer.cs
+++ b/Tests/EntityFramework/Model.Designer.cs
@@ -149,7 +149,7 @@ namespace SqlMapper.EntityFramework
                 {
                     OnIdChanging(value);
                     ReportPropertyChanging("Id");
-                    _Id = StructuralObject.SetValidValue(value, "Id");
+                    _Id = StructuralObject.SetValidValue(value);
                     ReportPropertyChanged("Id");
                     OnIdChanged();
                 }
@@ -174,7 +174,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnTextChanging(value);
                 ReportPropertyChanging("Text");
-                _Text = StructuralObject.SetValidValue(value, false, "Text");
+                _Text = StructuralObject.SetValidValue(value, false);
                 ReportPropertyChanged("Text");
                 OnTextChanged();
             }
@@ -198,7 +198,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCreationDateChanging(value);
                 ReportPropertyChanging("CreationDate");
-                _CreationDate = StructuralObject.SetValidValue(value, "CreationDate");
+                _CreationDate = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("CreationDate");
                 OnCreationDateChanged();
             }
@@ -222,7 +222,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnLastChangeDateChanging(value);
                 ReportPropertyChanging("LastChangeDate");
-                _LastChangeDate = StructuralObject.SetValidValue(value, "LastChangeDate");
+                _LastChangeDate = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("LastChangeDate");
                 OnLastChangeDateChanged();
             }
@@ -246,7 +246,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter1Changing(value);
                 ReportPropertyChanging("Counter1");
-                _Counter1 = StructuralObject.SetValidValue(value, "Counter1");
+                _Counter1 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter1");
                 OnCounter1Changed();
             }
@@ -270,7 +270,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter2Changing(value);
                 ReportPropertyChanging("Counter2");
-                _Counter2 = StructuralObject.SetValidValue(value, "Counter2");
+                _Counter2 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter2");
                 OnCounter2Changed();
             }
@@ -294,7 +294,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter3Changing(value);
                 ReportPropertyChanging("Counter3");
-                _Counter3 = StructuralObject.SetValidValue(value, "Counter3");
+                _Counter3 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter3");
                 OnCounter3Changed();
             }
@@ -318,7 +318,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter4Changing(value);
                 ReportPropertyChanging("Counter4");
-                _Counter4 = StructuralObject.SetValidValue(value, "Counter4");
+                _Counter4 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter4");
                 OnCounter4Changed();
             }
@@ -342,7 +342,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter5Changing(value);
                 ReportPropertyChanging("Counter5");
-                _Counter5 = StructuralObject.SetValidValue(value, "Counter5");
+                _Counter5 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter5");
                 OnCounter5Changed();
             }
@@ -366,7 +366,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter6Changing(value);
                 ReportPropertyChanging("Counter6");
-                _Counter6 = StructuralObject.SetValidValue(value, "Counter6");
+                _Counter6 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter6");
                 OnCounter6Changed();
             }
@@ -390,7 +390,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter7Changing(value);
                 ReportPropertyChanging("Counter7");
-                _Counter7 = StructuralObject.SetValidValue(value, "Counter7");
+                _Counter7 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter7");
                 OnCounter7Changed();
             }
@@ -414,7 +414,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter8Changing(value);
                 ReportPropertyChanging("Counter8");
-                _Counter8 = StructuralObject.SetValidValue(value, "Counter8");
+                _Counter8 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter8");
                 OnCounter8Changed();
             }
@@ -438,7 +438,7 @@ namespace SqlMapper.EntityFramework
             {
                 OnCounter9Changing(value);
                 ReportPropertyChanging("Counter9");
-                _Counter9 = StructuralObject.SetValidValue(value, "Counter9");
+                _Counter9 = StructuralObject.SetValidValue(value);
                 ReportPropertyChanged("Counter9");
                 OnCounter9Changed();
             }

--- a/Tests/EntityFramework/Model.edmx
+++ b/Tests/EntityFramework/Model.edmx
@@ -1,100 +1,68 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<edmx:Edmx Version="3.0" xmlns:edmx="http://schemas.microsoft.com/ado/2009/11/edmx">
+<edmx:Edmx Version="2.0" xmlns:edmx="http://schemas.microsoft.com/ado/2008/10/edmx">
   <!-- EF Runtime content -->
   <edmx:Runtime>
     <!-- SSDL content -->
     <edmx:StorageModels>
-    <Schema Namespace="tempdbModel.Store" Alias="Self" Provider="System.Data.SqlClient" ProviderManifestToken="2008" xmlns="http://schemas.microsoft.com/ado/2009/11/edm/ssdl">
-        <EntityContainer Name="tempdbModelStoreContainer">
-          <EntitySet Name="Posts" EntityType="tempdbModel.Store.Posts" store:Type="Tables" Schema="dbo" xmlns:store="http://schemas.microsoft.com/ado/2007/12/edm/EntityStoreSchemaGenerator" />
+      <Schema xmlns="http://schemas.microsoft.com/ado/2009/02/edm/ssdl" Namespace="tempdbModel.Store" Alias="Self" Provider="System.Data.SqlClient" ProviderManifestToken="2005">
+        <EntityContainer Name="tempdbModelTargetContainer" >
         </EntityContainer>
-        <EntityType Name="Posts">
-          <Key>
-            <PropertyRef Name="Id" />
-          </Key>
-          <Property Name="Id" Type="int" Nullable="false" StoreGeneratedPattern="Identity" />
-          <Property Name="Text" Type="varchar(max)" Nullable="false" />
-          <Property Name="CreationDate" Type="datetime" Nullable="false" />
-          <Property Name="LastChangeDate" Type="datetime" Nullable="false" />
-          <Property Name="Counter1" Type="int" />
-          <Property Name="Counter2" Type="int" />
-          <Property Name="Counter3" Type="int" />
-          <Property Name="Counter4" Type="int" />
-          <Property Name="Counter5" Type="int" />
-          <Property Name="Counter6" Type="int" />
-          <Property Name="Counter7" Type="int" />
-          <Property Name="Counter8" Type="int" />
-          <Property Name="Counter9" Type="int" />
-        </EntityType>
-      </Schema></edmx:StorageModels>
+      </Schema>
+    </edmx:StorageModels>
     <!-- CSDL content -->
     <edmx:ConceptualModels>
-      <Schema Namespace="tempdbModel" Alias="Self" xmlns="http://schemas.microsoft.com/ado/2009/11/edm">
-        <EntityContainer Name="tempdbEntities1" annotation:LazyLoadingEnabled="true" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation">
+      <Schema xmlns="http://schemas.microsoft.com/ado/2008/09/edm" xmlns:cg="http://schemas.microsoft.com/ado/2006/04/codegeneration" xmlns:store="http://schemas.microsoft.com/ado/2007/12/edm/EntityStoreSchemaGenerator" Namespace="tempdbModel" Alias="Self" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation">
+        <EntityContainer Name="tempdbModelContainer" annotation:LazyLoadingEnabled="true">
           <EntitySet Name="Posts" EntityType="tempdbModel.Post" />
         </EntityContainer>
         <EntityType Name="Post">
           <Key>
             <PropertyRef Name="Id" />
           </Key>
-          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
-          <Property Name="Text" Type="String" Nullable="false" MaxLength="Max" Unicode="false" FixedLength="false" />
-          <Property Name="CreationDate" Type="DateTime" Nullable="false" />
-          <Property Name="LastChangeDate" Type="DateTime" Nullable="false" />
-          <Property Name="Counter1" Type="Int32" />
-          <Property Name="Counter2" Type="Int32" />
-          <Property Name="Counter3" Type="Int32" />
-          <Property Name="Counter4" Type="Int32" />
-          <Property Name="Counter5" Type="Int32" />
-          <Property Name="Counter6" Type="Int32" />
-          <Property Name="Counter7" Type="Int32" />
-          <Property Name="Counter8" Type="Int32" />
-          <Property Name="Counter9" Type="Int32" />
+          <Property Type="Int32" Name="Id" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+          <Property Type="String" Name="Text" Nullable="false" MaxLength="Max" FixedLength="false" Unicode="false" />
+          <Property Type="DateTime" Name="CreationDate" Nullable="false" />
+          <Property Type="DateTime" Name="LastChangeDate" Nullable="false" />
+          <Property Type="Int32" Name="Counter1" />
+          <Property Type="Int32" Name="Counter2" />
+          <Property Type="Int32" Name="Counter3" />
+          <Property Type="Int32" Name="Counter4" />
+          <Property Type="Int32" Name="Counter5" />
+          <Property Type="Int32" Name="Counter6" />
+          <Property Type="Int32" Name="Counter7" />
+          <Property Type="Int32" Name="Counter8" />
+          <Property Type="Int32" Name="Counter9" />
         </EntityType>
       </Schema>
     </edmx:ConceptualModels>
     <!-- C-S mapping content -->
     <edmx:Mappings>
-      <Mapping Space="C-S" xmlns="http://schemas.microsoft.com/ado/2009/11/mapping/cs">
-        <EntityContainerMapping StorageEntityContainer="tempdbModelStoreContainer" CdmEntityContainer="tempdbEntities1">
-          <EntitySetMapping Name="Posts"><EntityTypeMapping TypeName="tempdbModel.Post"><MappingFragment StoreEntitySet="Posts">
-            <ScalarProperty Name="Id" ColumnName="Id" />
-            <ScalarProperty Name="Text" ColumnName="Text" />
-            <ScalarProperty Name="CreationDate" ColumnName="CreationDate" />
-            <ScalarProperty Name="LastChangeDate" ColumnName="LastChangeDate" />
-            <ScalarProperty Name="Counter1" ColumnName="Counter1" />
-            <ScalarProperty Name="Counter2" ColumnName="Counter2" />
-            <ScalarProperty Name="Counter3" ColumnName="Counter3" />
-            <ScalarProperty Name="Counter4" ColumnName="Counter4" />
-            <ScalarProperty Name="Counter5" ColumnName="Counter5" />
-            <ScalarProperty Name="Counter6" ColumnName="Counter6" />
-            <ScalarProperty Name="Counter7" ColumnName="Counter7" />
-            <ScalarProperty Name="Counter8" ColumnName="Counter8" />
-            <ScalarProperty Name="Counter9" ColumnName="Counter9" />
-          </MappingFragment></EntityTypeMapping></EntitySetMapping>
+      <Mapping xmlns="http://schemas.microsoft.com/ado/2008/09/mapping/cs" Space="C-S">
+        <Alias Key="Model" Value="tempdbModel" />
+        <Alias Key="Target" Value="tempdbModel.Store" />
+        <EntityContainerMapping CdmEntityContainer="tempdbModelContainer" StorageEntityContainer="tempdbModelTargetContainer">
         </EntityContainerMapping>
       </Mapping>
     </edmx:Mappings>
   </edmx:Runtime>
   <!-- EF Designer content (DO NOT EDIT MANUALLY BELOW HERE) -->
-  <Designer xmlns="http://schemas.microsoft.com/ado/2009/11/edmx">
-    <Connection>
+  <edmx:Designer xmlns="http://schemas.microsoft.com/ado/2008/10/edmx">
+    <edmx:Connection>
       <DesignerInfoPropertySet>
         <DesignerProperty Name="MetadataArtifactProcessing" Value="EmbedInOutputAssembly" />
       </DesignerInfoPropertySet>
-    </Connection>
-    <Options>
+    </edmx:Connection>
+    <edmx:Options>
       <DesignerInfoPropertySet>
         <DesignerProperty Name="ValidateOnBuild" Value="true" />
         <DesignerProperty Name="EnablePluralization" Value="True" />
-        <DesignerProperty Name="IncludeForeignKeysInModel" Value="True" />
       </DesignerInfoPropertySet>
-    </Options>
+    </edmx:Options>
     <!-- Diagram content (shape and connector positions) -->
-    <Diagrams>
-      <Diagram Name="Model">
-        <EntityTypeShape EntityType="tempdbModel.Post" Width="1.5" PointX="0.75" PointY="1" Height="3.7109993489583313" IsExpanded="true" />
+    <edmx:Diagrams>
+      <Diagram Name="tempdbModel" >
+        <EntityTypeShape EntityType="tempdbModel.Post" Width="1.5" PointX="3.8953059929866836" PointY="16.997335233258706" />
       </Diagram>
-    </Diagrams>
-  </Designer>
+    </edmx:Diagrams>
+  </edmx:Designer>
 </edmx:Edmx>

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -382,6 +382,14 @@ namespace SqlMapper
         // see http://stackoverflow.com/questions/16726709/string-format-with-sql-wildcard-causing-dapper-query-to-break
         public void CheckComplexConcat()
         {
+            var version = connection.Query<string>("SELECT SERVERPROPERTY('ProductVersion')").First();
+
+            if (int.Parse(version.Substring(0, version.IndexOf('.'))) < 11) {
+                Console.Write(" - SKIPPED (SQL Server isn't new enough!)");
+                
+                return;
+            }
+
             string end_wildcard = @"
 SELECT * FROM #users16726709
 WHERE (first_name LIKE CONCAT(@search_term, '%') OR last_name LIKE CONCAT(@search_term, '%'));";

--- a/Tests/app.config
+++ b/Tests/app.config
@@ -4,6 +4,6 @@
   <connectionStrings>
     <add name="Smackdown.Properties.Settings.tempdbConnectionString" connectionString="Data Source=.;Initial Catalog=tempdb;Integrated Security=True" providerName="System.Data.SqlClient"/><add name="tempdbEntities" connectionString="metadata=res://*/EntityFramework.Model.csdl|res://*/EntityFramework.Model.ssdl|res://*/EntityFramework.Model.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=.;initial catalog=tempdb;integrated security=True;multipleactiveresultsets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient"/><add name="tempdbEntities1" connectionString="metadata=res://*/EntityFramework.Model.csdl|res://*/EntityFramework.Model.ssdl|res://*/EntityFramework.Model.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=.;initial catalog=tempdb;integrated security=True;multipleactiveresultsets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient"/></connectionStrings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
   </startup>
 </configuration>


### PR DESCRIPTION
I've just now updated to VS 2012, but before doing so I realised that the VS 2010 solution was pretty messed up.

I'm not sure if there's any desire to keep it reasonably maintained for people who are only targeting 3.5/4.0, but if so I've gone ahead and cleaned things up, including changing the 4.0 target test project to actually target and work with 4.0.

There was also a test case which was a response to [a Stack Overflow question reporting a non-bug](http://stackoverflow.com/questions/16726709/string-format-with-sql-wildcard-causing-dapper-query-to-break) that can only ever work against SQL Server 2012. For lack of a better solution, I put in a version check to prevent the test from throwing an exception when the statement isn't expected to work to begin with.
