### PR TITLE
Fix broken link to SqlMapper.cs in the readme file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@ Dapper - a simple object mapper for .Net
 
 Features
 --------
-Dapper is a [single file](https://github.com/SamSaffron/dapper-dot-net/blob/master/Dapper/SqlMapper.cs) you can drop in to your project that will extend your IDbConnection interface.
+Dapper is a [single file](https://github.com/SamSaffron/dapper-dot-net/blob/master/Dapper%20NET40/SqlMapper.cs) you can drop in to your project that will extend your IDbConnection interface.
 
 It provides 3 helpers:
 


### PR DESCRIPTION
Just noticed the link to SqlMapper was broken as I was reading the docs, and tried to use my advanced markdown skills to fix it :)
