### PR TITLE
Add mapping for query fields containing underscores to properties with the same name without underscores

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -3385,13 +3385,17 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
         public SqlMapper.IMemberMap GetMember(string columnName)
         {
             var property = _properties.FirstOrDefault(p => string.Equals(p.Name, columnName, StringComparison.Ordinal))
-               ?? _properties.FirstOrDefault(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase));
+               ?? _properties.FirstOrDefault(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase))
+               ?? _properties.FirstOrDefault(p => string.Equals(p.Name, columnName.Replace("_", ""), StringComparison.Ordinal))
+               ?? _properties.FirstOrDefault(p => string.Equals(p.Name, columnName.Replace("_", ""), StringComparison.OrdinalIgnoreCase));
 
             if (property != null)
                 return new SimpleMemberMap(columnName, property);
 
             var field = _fields.FirstOrDefault(p => string.Equals(p.Name, columnName, StringComparison.Ordinal))
-               ?? _fields.FirstOrDefault(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase));
+               ?? _fields.FirstOrDefault(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase))
+               ?? _fields.FirstOrDefault(p => string.Equals(p.Name, columnName.Replace("_", ""), StringComparison.Ordinal))
+               ?? _fields.FirstOrDefault(p => string.Equals(p.Name, columnName.Replace("_", ""), StringComparison.OrdinalIgnoreCase));
 
             if (field != null)
                 return new SimpleMemberMap(columnName, field);

--- a/DapperTests NET35/Tests.cs
+++ b/DapperTests NET35/Tests.cs
@@ -17,12 +17,14 @@ namespace DapperTests_NET35
         }
         public void TestClassWithStringUsage()
         {
-            var arr = connection.Query<BasicType>("select 'abc' as [Value] union all select @txt", new { txt = "def" }).ToArray();
+            var arr = connection.Query<BasicType>("select 'abc' as [Value], '123' as [Another_Value] union all select @txt, @txt2", new { txt = "def", txt2 = "456" }).ToArray();
             arr.Select(x => x.Value).IsSequenceEqualTo(new[] { "abc", "def" });
+            arr.Select(x => x.AnotherValue).IsSequenceEqualTo(new[] { "123", "456" });
         }
         class BasicType
         { 
             public string Value { get; set; }
+            public string AnotherValue { get; set; }
         }
 
         public void TestDynamicSimulatedQuery() {


### PR DESCRIPTION
Example:
Database field "Customer_ID" is now mapped to class property/field "CustomerID" (case insensitive)
