### PR TITLE
Dapper.Contrib - Fix broken properties cache.

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -63,7 +63,7 @@ namespace Dapper.Contrib.Extensions
                 return pis;
             }
 
-            var properties = type.GetProperties().Where(IsWriteable);
+            var properties = type.GetProperties().Where(IsWriteable).ToArray();
             TypeProperties[type.TypeHandle] = properties;
             return properties;
         }


### PR DESCRIPTION
Without this TypePropertiesCache does not actually cache the IsWriteable result, so we re-iterate the IEnumerable and evaluate IsWritable every time. All this reflection (and LINQ) adds up.

Profile from our app, before on left.
![capture](https://f.cloud.github.com/assets/393086/998661/8df2474a-0a09-11e3-9154-d455848f7d8f.PNG)

I've also changed the caches to be more strict on the type of the IEnumerable rather than passing IEnumerable everywhere and assuming multiple iterations are okay.
