### PR TITLE
Fix link to SqlMapper.cs in Readme.md.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@ Dapper - a simple object mapper for .Net
 
 Features
 --------
-Dapper is a [single file](https://github.com/SamSaffron/dapper-dot-net/blob/master/Dapper/SqlMapper.cs) you can drop in to your project that will extend your IDbConnection interface.
+Dapper is a [single file](https://github.com/SamSaffron/dapper-dot-net/blob/master/Dapper%20NET40/SqlMapper.cs) you can drop in to your project that will extend your IDbConnection interface.
 
 It provides 3 helpers:
 


### PR DESCRIPTION
It may also be desirable to add a note about the asynchronous methods defined in `SqlMapperAsync.cs` as well.
