### PR TITLE
Update to Readme.md (fix to "single file" link to SqlMapper.cs)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@ Dapper - a simple object mapper for .Net
 
 Features
 --------
-Dapper is a [single file](https://github.com/SamSaffron/dapper-dot-net/blob/master/Dapper/SqlMapper.cs) you can drop in to your project that will extend your IDbConnection interface.
+Dapper is a [single file](https://github.com/SamSaffron/dapper-dot-net/blob/master/Dapper%20NET40/SqlMapper.cs) you can drop in to your project that will extend your IDbConnection interface.
 
 It provides 3 helpers:
 


### PR DESCRIPTION
The link to the SqlMapper.cs file was giving a 404. Now points to https://github.com/SamSaffron/dapper-dot-net/blob/master/Dapper%20NET40/SqlMapper.cs
