### PR TITLE
Add support for getting results as DataSets and DataTables

### DIFF
--- a/Dapper NET35/Dapper NET35.csproj
+++ b/Dapper NET35/Dapper NET35.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Dapper NET40\Properties\AssemblyInfo.cs">

--- a/Dapper NET40/Dapper NET40.csproj
+++ b/Dapper NET40/Dapper NET40.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SqlMapper.cs" />

--- a/Dapper NET45/Dapper NET45.csproj
+++ b/Dapper NET45/Dapper NET45.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Dapper NET40\Properties\AssemblyInfo.cs">

--- a/DapperTests NET45/Tests.cs
+++ b/DapperTests NET45/Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Data;
+using System.Linq;
 using Dapper;
 using SqlMapper;
 
@@ -43,6 +44,44 @@ namespace DapperTests_NET45
                 product.Name.IsEqualTo("abc");
                 product.Category.Id.IsEqualTo(2);
                 product.Category.Name.IsEqualTo("def");
+            }
+        }
+
+        public void TestDataSet()
+        {
+            string sql = "select * from (select 1 as Id union all select 2 union all select 3) as X where Id in @Ids";
+
+            using (var connection = Program.GetOpenConnection())
+            {
+                var query = connection.QueryDataSetAsync(sql, new { Ids = new[] { 1, 2, 3 } });
+                DataSet ds = query.Result;
+
+                ds.IsNotNull();
+                ds.Tables.Count.IsEqualTo(1);
+
+                DataTable dt = ds.Tables[0];
+
+                dt.Rows.Count.IsEqualTo(3);
+                dt.Rows[0]["Id"].IsEqualTo(1);
+                dt.Rows[1]["Id"].IsEqualTo(2);
+                dt.Rows[2]["Id"].IsEqualTo(3);
+            }
+        }
+
+        public void TestDataTable()
+        {
+            string sql = "select * from (select 1 as Id union all select 2 union all select 3) as X where Id in @Ids";
+
+            using (var connection = Program.GetOpenConnection())
+            {
+                var query = connection.QueryDataTableAsync(sql, new { Ids = new[] { 1, 2, 3 } });
+                DataTable dt = query.Result;
+
+                dt.IsNotNull();
+                dt.Rows.Count.IsEqualTo(3);
+                dt.Rows[0]["Id"].IsEqualTo(1);
+                dt.Rows[1]["Id"].IsEqualTo(2);
+                dt.Rows[2]["Id"].IsEqualTo(3);
             }
         }
 

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -2645,6 +2645,61 @@ end");
             public decimal? D { get; set; }
         }
 
+        public void TestDataSet_Populate()
+        {
+            DataSet ds = connection.QueryDataSet("select * from (select 1 as Id union all select 2 union all select 3) as X where Id in @Ids", new { Ids = new[] { 1, 2, 3 } });
+
+            ds.IsNotNull();
+            ds.Tables.Count.IsEqualTo(1);
+
+            DataTable dt = ds.Tables[0];
+
+            dt.Rows.Count.IsEqualTo(3);
+            dt.Rows[0]["Id"].IsEqualTo(1);
+            dt.Rows[1]["Id"].IsEqualTo(2);
+            dt.Rows[2]["Id"].IsEqualTo(3);
+        }
+
+        public void TestDataSet_MultipleResultSets()
+        {
+            DataSet ds = connection.QueryDataSet("select @Count as Count; select @Name as Name;", new { Count = 1, Name = "foo" });
+
+            ds.IsNotNull();
+            ds.Tables.Count.IsEqualTo(2);
+
+            DataTable dt = ds.Tables[0];
+            dt.Rows.Count.IsEqualTo(1);
+            dt.Rows[0]["Count"].IsEqualTo(1);
+
+            dt = ds.Tables[1];
+            dt.Rows.Count.IsEqualTo(1);
+            dt.Rows[0]["Name"].IsEqualTo("foo");
+        }
+
+        public void TestDataSet_NoResultSets()
+        {
+            DataSet ds = connection.QueryDataSet("print 'no selects';");
+            ds.IsNull();
+        }
+
+        public void TestDataTable_Populate()
+        {
+            DataTable dt = connection.QueryDataTable("select * from (select 1 as Id union all select 2 union all select 3) as X where Id in @Ids", new { Ids = new[] { 1, 2, 3 } });
+
+            dt.IsNotNull();
+            dt.Rows.Count.IsEqualTo(3);
+            dt.Rows[0]["Id"].IsEqualTo(1);
+            dt.Rows[1]["Id"].IsEqualTo(2);
+            dt.Rows[2]["Id"].IsEqualTo(3);
+        }
+
+        public void TestDataSet_NoResults()
+        {
+            DataTable dt = connection.QueryDataTable("print 'no selects';");
+            dt.IsNull();
+        }
+
+
 #if POSTGRESQL
 
         class Cat


### PR DESCRIPTION
I realize that adding support for DataSets and DataTables is almost like taking a step backwards in a way.

However, there are many of us who unfortunately still need to use DataSets/DataTables to work with various third-party libraries. With Dapper's excellent parameter handling and support for lists, there is a huge advantage to being able to use Dapper like this.

I added `QueryDataSet()` and `QueryDataTable()` extension methods along with Async versions and some tests. A reference to System.XML was required, but I don't see why that would cause any problems.
