### PR TITLE
Make parameter filtering truly culture-insensitive

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -1833,7 +1833,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
 
         private static IEnumerable<PropertyInfo> FilterParameters(IEnumerable<PropertyInfo> parameters, string sql)
         {
-            return parameters.Where(p => Regex.IsMatch(sql, @"[?@:]" + p.Name + "([^a-zA-Z0-9_]+|$)", RegexOptions.IgnoreCase | RegexOptions.Multiline));
+            return parameters.Where(p => Regex.IsMatch(sql, @"[?@:]" + p.Name + "([^a-zA-Z0-9_]+|$)", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant));
         }
 
 
@@ -1924,15 +1924,6 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
 
             foreach (var prop in props)
             {
-                if (filterParams)
-                {
-                    if (identity.sql.IndexOf("@" + prop.Name, StringComparison.InvariantCultureIgnoreCase) < 0
-                        && identity.sql.IndexOf(":" + prop.Name, StringComparison.InvariantCultureIgnoreCase) < 0
-                        && identity.sql.IndexOf("?" + prop.Name, StringComparison.InvariantCultureIgnoreCase) < 0)
-                    { // can't see the parameter in the text (even in a comment, etc) - burn it with fire
-                        continue;
-                    }
-                }
                 if (typeof(ICustomQueryParameter).IsAssignableFrom(prop.PropertyType))
                 {
                     il.Emit(OpCodes.Ldloc_0); // stack is now [parameters] [typed-param]

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -13,6 +13,8 @@ using System.Dynamic;
 using System.ComponentModel;
 using Microsoft.CSharp.RuntimeBinder;
 using System.Data.Common;
+using System.Globalization;
+using System.Threading;
 #if POSTGRESQL
 using Npgsql;
 #endif
@@ -2635,6 +2637,16 @@ end");
             row.B.IsNull();
             row.C.Equals(0.0M);
             row.D.IsNull();
+        }
+
+        public void TestParameterInclusionNotSensitiveToCurrentCulture()
+        {
+            CultureInfo current = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+
+            connection.Query<int>("select @pid", new { PId = 1 }).Single();
+
+            Thread.CurrentThread.CurrentCulture = current;
         }
 
         class HasDoubleDecimal


### PR DESCRIPTION
Dapper's parameter filtering is currently case-insensitive, but relies on the current culture (depending on which bit of code you look at). In situations where the current culture is variable, certain cultures may unexpectedly produce exceptions when the parameter name in-query is in a different case than the property of the provided parameter object.

Making the FilterParameters regex RegexOptions.CultureInvariant fixes this, and I removed a seemingly redundant check for the variable presence within the loop that already did the case-insensitive culture-invariant comparison.
