### PR TITLE
Added support for ICustomQueryParameters to be members of a dictionary t...

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -3112,14 +3112,19 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
                 var dbType = param.DbType;
                 var val = param.Value;
                 string name = Clean(param.Name);
+                var isCustomQueryParameter = typeof(SqlMapper.ICustomQueryParameter).IsAssignableFrom(val.GetType());
 
-                if (dbType == null && val != null) dbType = SqlMapper.LookupDbType(val.GetType(), name);
+                if (dbType == null && val != null && !isCustomQueryParameter) dbType = SqlMapper.LookupDbType(val.GetType(), name);
 
                 if (dbType == DynamicParameters.EnumerableMultiParameter)
                 {
 #pragma warning disable 612, 618
                     SqlMapper.PackListParameters(command, name, val);
 #pragma warning restore 612, 618
+                }
+                else if (isCustomQueryParameter)
+                {
+                    ((SqlMapper.ICustomQueryParameter)val).AddParameter(command, name);
                 }
                 else
                 {


### PR DESCRIPTION
...hat can then be passed into a new DynamicParameters object.

Generally, working with an IDictionary<string,object> and DynamicParameters has worked well, either through construction of DynamicParameters or the 'Add' method (such as new DynamiceParameters(<dictionary>).  However, when one of the entries in the dictionary is an ICustomQueryParameter, it would blow up in the SqlMapper.LookupDbType method.  This allows parameters that are part of a dictionary to simply call 'AddParameter' passing in the command and name and having them function as expected. 

(My apologies regarding the file diff on line 3613...I can't seem to get the correct carriage return so that it appears unchanged.)
