### PR TITLE
Fixed ArgumentException with DbString parameter list on Oracle

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -1789,7 +1789,6 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                         count++;
                         var listParam = command.CreateParameter();
                         listParam.ParameterName = namePrefix + count;
-                        listParam.Value = item ?? DBNull.Value;
                         if (isString)
                         {
                             listParam.Size = 4000;
@@ -1805,6 +1804,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                         }
                         else
                         {
+                            listParam.Value = item ?? DBNull.Value;
                             command.Parameters.Add(listParam);
                         }
                     }


### PR DESCRIPTION
Passing a DbString list parameter to a `Query<T>` or `Execute` call causes an ArgumentException to be thrown by Oracle.DataAccess.

This happens into `PackListParameters`:

``` c#
listParam.Value = item ?? DBNull.Value;
```

throws an ArgumentException if listParam is an OracleParameter and item is a DbString.
