### PR TITLE
Fix missing `DataAnnotations` assembly

### DIFF
--- a/Dapper.Contrib/Dapper.Contrib.nuspec
+++ b/Dapper.Contrib/Dapper.Contrib.nuspec
@@ -17,6 +17,7 @@
       <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.0-Client, .NETFramework4.0" />
       <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.0-Client, .NETFramework4.0" />
       <frameworkAssembly assemblyName="System.Data" targetFramework=".NETFramework4.0-Client, .NETFramework4.0" />
+      <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework=".NETFramework4.0-Client, .NETFramework4.0" />
       <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0-Client, .NETFramework4.0" />
     </frameworkAssemblies>
   </metadata>


### PR DESCRIPTION
I just installed Dapper.Contrib through NuGet and got a message
saying `System.ComponentModel.DataAnnotations` was missing.

This PR adds that assembly to the NuSpec.  I've never messed with NuGet Spec files before, so you should _DEFINITELY_ check my work.
