### PR TITLE
Null check related to Pull Request #100 bug fix.

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -3325,7 +3325,7 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
                 var dbType = param.DbType;
                 var val = param.Value;
                 string name = Clean(param.Name);
-                var isCustomQueryParameter = typeof(SqlMapper.ICustomQueryParameter).IsAssignableFrom(val.GetType());
+                var isCustomQueryParameter = val != null && typeof(SqlMapper.ICustomQueryParameter).IsAssignableFrom(val.GetType());
 
                 if (dbType == null && val != null && !isCustomQueryParameter) dbType = SqlMapper.LookupDbType(val.GetType(), name);
 


### PR DESCRIPTION
We can't call val.GetType() if it's null!  This will assume that null types are not in fact custom query parameters which is what the previous behavior was.  This now passes tests (and was previously breaking).
