### PR TITLE
AmbiguousMatchException with multiple indexers

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -4093,7 +4093,13 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
         {
             return propertyInfo.DeclaringType == type ?
                 propertyInfo.GetSetMethod(true) :
-                propertyInfo.DeclaringType.GetProperty(propertyInfo.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).GetSetMethod(true);
+                propertyInfo.DeclaringType.GetProperty(
+                   propertyInfo.Name,
+                   BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                   Type.DefaultBinder,
+                   propertyInfo.PropertyType,
+                   propertyInfo.GetIndexParameters().Select(p => p.ParameterType).ToArray(),
+                   null).GetSetMethod(true);
         }
 
         internal static List<PropertyInfo> GetSettableProps(Type t)

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -2288,6 +2288,26 @@ end");
             var item = connection.Query<int>("#TestProcWithIndexer", new ParameterWithIndexer(), commandType: CommandType.StoredProcedure).Single();
         }
 
+        public class MultipleParametersWithIndexerDeclaringType
+        {
+            public object this[object field] { get { return null; } set { } }
+            public object this[object field, int index] { get { return null; } set { } }
+            public int B { get; set; }
+        }
+
+        public class MultipleParametersWithIndexer : MultipleParametersWithIndexerDeclaringType
+        {
+            public int A { get; set; }
+        }
+
+        public void TestMultipleParametersWithIndexer()
+        {
+            var order = connection.Query<MultipleParametersWithIndexer>("select 1 A,2 B").First();
+
+            order.A.IsEqualTo(1);
+            order.B.IsEqualTo(2);
+        }
+
         public void Issue_40_AutomaticBoolConversion()
         {
             var user = connection.Query<Issue40_User>("select UserId=1,Email='abc',Password='changeme',Active=cast(1 as tinyint)").Single();


### PR DESCRIPTION
An AmbiguousMatchException is encountered when

`Type.GetProperty(String, BindingFlags)`

is used and there are multiple indexers on the type, so it was replaced with a call to

`Type.GetProperty(String, BindingFlags, Binder, Type, Type[], ParameterModifier[])`
