### PR TITLE
Removing xapfest.com from Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -352,6 +352,6 @@ Who is using this?
 ---------------------
 Dapper is in production use at:
 
-[Stack Overflow](http://stackoverflow.com/), [xpfest.com](http://www.xapfest.com/), [helpdesk](http://www.jitbit.com/helpdesk-software/)
+[Stack Overflow](http://stackoverflow.com/), [helpdesk](http://www.jitbit.com/helpdesk-software/)
 
 (if you would like to be listed here let me know)


### PR DESCRIPTION
Seems to me like xapfest.com domain is dead so removing it from Readme file
