### PR TITLE
IsConsumed bool field for MultiQuery

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -3728,6 +3728,13 @@ Type type, IDataReader reader, int startBound = 0, int length = -1, bool returnN
             }
             private int gridIndex, readCount;
             private bool consumed;
+            public bool IsConsumed
+            {
+                get
+                {
+                    return consumed;
+                }
+            }
             private void NextResult()
             {
                 if (reader.NextResult())


### PR DESCRIPTION
I needed a way to add an unknown amount of query results to a List()

```
List<IEnumerable<dynamic>> resultSets = new List<IEnumerable<dynamic>>();

using (var sqlConnection = Utilities.GetCustConnection(requestData.ClientID))
using (var results = sqlConnection.QueryMultiple(sqlStatement, new { programID = requestData.ProgramID, itemID = itemID, profileTableOI = requestData.UserOI }))
{
    while (!results.IsConsumed)
    {
        resultSets.Add(results.Read());
    }
}
```
