### PR TITLE
Added support for using template with WHERE already in it

### DIFF
--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -115,6 +115,11 @@ namespace Dapper
             return new Template(this, sql, parameters, hasExistingWhere);
         }
 
+        public Template AddTemplate(string sql, dynamic parameters = null)
+        {
+            return new Template(this, sql, parameters, false);
+        }
+
         void AddClause(string name, string sql, object parameters, string joiner, string prefix = "", string postfix = "", bool IsInclusive = false)
         {
             Clauses clauses;

--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Dapper
 {
@@ -49,6 +47,11 @@ namespace Dapper
                               })) + postfix
                     : prefix + string.Join(joiner, this.Select(c => c.Sql)) + postfix;
             }
+
+            public void SetPrefix(string value)
+            {
+                prefix = value;
+            }
         }
 
         public class Template
@@ -56,13 +59,16 @@ namespace Dapper
             readonly string sql;
             readonly SqlBuilder builder;
             readonly object initParams;
+            readonly bool hasExistingWhere;
+
             int dataSeq = -1; // Unresolved
 
-            public Template(SqlBuilder builder, string sql, dynamic parameters)
+            public Template(SqlBuilder builder, string sql, dynamic parameters, bool hasExistingWhere = false)
             {
                 this.initParams = parameters;
                 this.sql = sql;
                 this.builder = builder;
+                this.hasExistingWhere = hasExistingWhere;
             }
 
             static System.Text.RegularExpressions.Regex regex =
@@ -78,6 +84,9 @@ namespace Dapper
 
                     foreach (var pair in builder.data)
                     {
+                        if (hasExistingWhere && pair.Key == "where")
+                            pair.Value.SetPrefix(" AND ");
+
                         rawSql = rawSql.Replace("/**" + pair.Key + "**/", pair.Value.ResolveClauses(p));
                     }
                     parameters = p;
@@ -101,9 +110,9 @@ namespace Dapper
         {
         }
 
-        public Template AddTemplate(string sql, dynamic parameters = null)
+        public Template AddTemplate(string sql, dynamic parameters = null, bool hasExistingWhere = false)
         {
-            return new Template(this, sql, parameters);
+            return new Template(this, sql, parameters, hasExistingWhere);
         }
 
         void AddClause(string name, string sql, object parameters, string joiner, string prefix = "", string postfix = "", bool IsInclusive = false)
@@ -123,7 +132,7 @@ namespace Dapper
             AddClause("intersect", sql, parameters, joiner: "\nINTERSECT\n ", prefix: "\n ", postfix: "\n");
             return this;
         }
-        
+
         public SqlBuilder InnerJoin(string sql, dynamic parameters = null)
         {
             AddClause("innerjoin", sql, parameters, joiner: "\nINNER JOIN ", prefix: "\nINNER JOIN ", postfix: "\n");
@@ -153,7 +162,7 @@ namespace Dapper
             AddClause("where", sql, parameters, " AND ", prefix: "WHERE ", postfix: "\n", IsInclusive: true);
             return this;
         }
-        
+
         public SqlBuilder OrderBy(string sql, dynamic parameters = null)
         {
             AddClause("orderby", sql, parameters, " , ", prefix: "ORDER BY ", postfix: "\n");


### PR DESCRIPTION
Many times, I have a template with a lot of WHERE already there, and want to add stuff dynamically.

This adds a flag so you can specify that the template already has a WHERE clause, so the dynamic where's are connected with AND instead of WHERE.
