### PR TITLE
Actually pass IsInclusive param to Clause so OrWhere can work

### DIFF
--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -114,7 +114,7 @@ namespace Dapper
                 clauses = new Clauses(joiner, prefix, postfix);
                 data[name] = clauses;
             }
-            clauses.Add(new Clause { Sql = sql, Parameters = parameters });
+            clauses.Add(new Clause { Sql = sql, Parameters = parameters, IsInclusive = IsInclusive });
             seq++;
         }
 


### PR DESCRIPTION
Looks like this was never set on the clause even though it was passed to AddClause. That means OrWhere never would actually create a OR where in the output SQL, but always use AND. Did #124 ever actually work?

Are there not tests for SqlBuilder or am I missing something?
