### PR TITLE
Property of type Table<TDatabase, TId> results in a null value for property

### DIFF
--- a/Dapper.Rainbow NET45/DatabaseAsync.cs
+++ b/Dapper.Rainbow NET45/DatabaseAsync.cs
@@ -18,12 +18,17 @@ namespace Dapper
             /// Insert a row into the db asynchronously
             /// </summary>
             /// <param name="data">Either DynamicParameters or an anonymous type or concrete type</param>
+            /// <param name="removeId">Leave true if the database column is an identity or auto incrementing otherwise set to false and the Id property value will be inserted.</param>
             /// <returns></returns>
-            public virtual async Task<int?> InsertAsync(dynamic data)
+            public virtual async Task<int?> InsertAsync(dynamic data, bool removeId = true)
             {
                 var o = (object)data;
                 List<string> paramNames = GetParamNames(o);
-                paramNames.Remove("Id");
+                
+                if (removeId)
+                {
+                    paramNames.Remove("Id");
+                }
 
                 string cols = string.Join(",", paramNames);
                 string cols_params = string.Join(",", paramNames.Select(p => "@" + p));

--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -49,12 +49,17 @@ namespace Dapper
             /// Insert a row into the db
             /// </summary>
             /// <param name="data">Either DynamicParameters or an anonymous type or concrete type</param>
+            /// <param name="removeId">Leave true if the database column is an identity or auto incrementing otherwise set to false and the Id property value will be inserted.</param>
             /// <returns></returns>
-            public virtual int? Insert(dynamic data)
+            public virtual int? Insert(dynamic data, bool removeId = true)
             {
                 var o = (object)data;
                 List<string> paramNames = GetParamNames(o);
-                paramNames.Remove("Id");
+                
+                if (removeId)
+                {
+                    paramNames.Remove("Id");
+                }
 
                 string cols = string.Join(",", paramNames);
                 string cols_params = string.Join(",", paramNames.Select(p => "@" + p));

--- a/Dapper.Rainbow/SqlCompactDatabase.cs
+++ b/Dapper.Rainbow/SqlCompactDatabase.cs
@@ -18,12 +18,17 @@ namespace Dapper.Rainbow
             /// Insert a row into the db
             /// </summary>
             /// <param name="data">Either DynamicParameters or an anonymous type or concrete type</param>
+            /// <param name="removeId">Leave true if the database column is an identity or auto incrementing otherwise set to false and the Id property value will be inserted.</param>
             /// <returns></returns>
-            public override int? Insert(dynamic data)
+            public override int? Insert(dynamic data, bool removeId = true)
             {
                 var o = (object)data;
                 List<string> paramNames = GetParamNames(o);
-                paramNames.Remove("Id");
+                
+                if (removeId)
+                {
+                    paramNames.Remove("Id");
+                }
 
                 string cols = string.Join(",", paramNames);
                 string cols_params = string.Join(",", paramNames.Select(p => "@" + p));


### PR DESCRIPTION
For Dapper.Rainbow, declaring a property as Table<TDatabase,TId> will result in a null value for the property after calling Database.Init because the method to generate the constructor does not account for the type Table<,>. This pull request fixes that problem. 

The workaround for this bug would be to subclass Table<TDatabase, TId> like "StringTable : Table<TDatabase, string>" and then declare the properties as StringTable versus Table<TDatabase, TId>.
