### PR TITLE
Dapper Contrib - Column mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Test.DB.*
 TestResults/
 Dapper.Tests/*.sdf
 .dotnet/*
+.idea.*/
+Dapper.userprefs

--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -33,7 +33,7 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(GetAsync));
                 var name = GetTableName(type);
 
-                sql = $"SELECT * FROM {name} WHERE {key.Name} = @id";
+                sql = $"SELECT * FROM {name} WHERE {key.ColumnName} = @id";
                 GetQueries[type.TypeHandle] = sql;
             }
 
@@ -52,8 +52,8 @@ namespace Dapper.Contrib.Extensions
 
             foreach (var property in TypePropertiesCache(type))
             {
-                var val = res[property.Name];
-                property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                var val = res[property.ColumnName];
+                property.PropertyInfo.SetValue(obj, Convert.ChangeType(val, property.PropertyInfo.PropertyType), null);
             }
 
             ((IProxy)obj).IsDirty = false;   //reset change tracking and return
@@ -102,8 +102,8 @@ namespace Dapper.Contrib.Extensions
                 var obj = ProxyGenerator.GetInterfaceProxy<T>();
                 foreach (var property in TypePropertiesCache(type))
                 {
-                    var val = res[property.Name];
-                    property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    var val = res[property.ColumnName];
+                    property.PropertyInfo.SetValue(obj, Convert.ChangeType(val, property.PropertyInfo.PropertyType), null);
                 }
                 ((IProxy)obj).IsDirty = false;   //reset change tracking and return
                 list.Add(obj);
@@ -142,25 +142,23 @@ namespace Dapper.Contrib.Extensions
 
             var name = GetTableName(type);
             var sbColumnList = new StringBuilder(null);
-            var allProperties = TypePropertiesCache(type);
+            var persistentProperties = PersistentPropertiesCache(type);
             var keyProperties = KeyPropertiesCache(type);
-            var computedProperties = ComputedPropertiesCache(type);
-            var allPropertiesExceptKeyAndComputed = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
 
-            for (var i = 0; i < allPropertiesExceptKeyAndComputed.Count; i++)
+            for (var i = 0; i < persistentProperties.Count; i++)
             {
-                var property = allPropertiesExceptKeyAndComputed.ElementAt(i);
-                sqlAdapter.AppendColumnName(sbColumnList, property.Name);
-                if (i < allPropertiesExceptKeyAndComputed.Count - 1)
+                var property = persistentProperties.ElementAt(i);
+                sqlAdapter.AppendColumnName(sbColumnList, property.ColumnName);
+                if (i < persistentProperties.Count - 1)
                     sbColumnList.Append(", ");
             }
 
             var sbParameterList = new StringBuilder(null);
-            for (var i = 0; i < allPropertiesExceptKeyAndComputed.Count; i++)
+            for (var i = 0; i < persistentProperties.Count; i++)
             {
-                var property = allPropertiesExceptKeyAndComputed.ElementAt(i);
-                sbParameterList.AppendFormat("@{0}", property.Name);
-                if (i < allPropertiesExceptKeyAndComputed.Count - 1)
+                var property = persistentProperties.ElementAt(i);
+                sbParameterList.AppendFormat("@{0}", property.ColumnName);
+                if (i < persistentProperties.Count - 1)
                     sbParameterList.Append(", ");
             }
 
@@ -204,34 +202,30 @@ namespace Dapper.Contrib.Extensions
             }
 
             var keyProperties = KeyPropertiesCache(type);
-            var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
-            if (!keyProperties.Any() && !explicitKeyProperties.Any())
-                throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");
+            if (!keyProperties.Any())
+                throw new ArgumentException("Entity must have at least one key property, defined by GetKeyProperties. By default, use [Key] or [ExplicitKey] property");
 
             var name = GetTableName(type);
 
             var sb = new StringBuilder();
             sb.AppendFormat("update {0} set ", name);
-
-            var allProperties = TypePropertiesCache(type);
-            keyProperties.AddRange(explicitKeyProperties);
-            var computedProperties = ComputedPropertiesCache(type);
-            var nonIdProps = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
+            
+            var persistentProperties = PersistentPropertiesCache(type);
 
             var adapter = GetFormatter(connection);
 
-            for (var i = 0; i < nonIdProps.Count; i++)
+            for (var i = 0; i < persistentProperties.Count; i++)
             {
-                var property = nonIdProps.ElementAt(i);
-                adapter.AppendColumnNameEqualsValue(sb, property.Name);
-                if (i < nonIdProps.Count - 1)
+                var property = persistentProperties.ElementAt(i);
+                adapter.AppendColumnNameEqualsValue(sb, property.ColumnName);
+                if (i < persistentProperties.Count - 1)
                     sb.AppendFormat(", ");
             }
             sb.Append(" where ");
             for (var i = 0; i < keyProperties.Count; i++)
             {
                 var property = keyProperties.ElementAt(i);
-                adapter.AppendColumnNameEqualsValue(sb, property.Name);
+                adapter.AppendColumnNameEqualsValue(sb, property.ColumnName);
                 if (i < keyProperties.Count - 1)
                     sb.AppendFormat(" and ");
             }
@@ -265,12 +259,10 @@ namespace Dapper.Contrib.Extensions
             }
 
             var keyProperties = KeyPropertiesCache(type);
-            var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
-            if (!keyProperties.Any() && !explicitKeyProperties.Any())
-                throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");
+            if (!keyProperties.Any())
+                throw new ArgumentException("Entity must have at least one key property, defined by GetKeyProperties. By default, use [Key] or [ExplicitKey] property");
 
             var name = GetTableName(type);
-            keyProperties.AddRange(explicitKeyProperties);
 
             var sb = new StringBuilder();
             sb.AppendFormat("DELETE FROM {0} WHERE ", name);
@@ -278,7 +270,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < keyProperties.Count; i++)
             {
                 var property = keyProperties.ElementAt(i);
-                sb.AppendFormat("{0} = @{1}", property.Name, property.Name);
+                sb.AppendFormat("{0} = @{1}", property.ColumnName, property.ColumnName);
                 if (i < keyProperties.Count - 1)
                     sb.AppendFormat(" AND ");
             }
@@ -306,12 +298,12 @@ namespace Dapper.Contrib.Extensions
 
 public partial interface ISqlAdapter
 {
-    Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, String tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert);
+    Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, String tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert);
 }
 
 public partial class SqlServerAdapter
 {
-    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, String tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, String tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var cmd = $"INSERT INTO {tableName} ({columnList}) values ({parameterList}); SELECT SCOPE_IDENTITY() id";
         var multi = await connection.QueryMultipleAsync(cmd, entityToInsert, transaction, commandTimeout);
@@ -320,10 +312,10 @@ public partial class SqlServerAdapter
         if (first == null || first.id == null) return 0;
 
         var id = (int)first.id;
-        var pi = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!pi.Any()) return id;
+        
+        if (!keyProperties.Any()) return id;
 
-        var idp = pi.First();
+        var idp = keyProperties.First().PropertyInfo;
         idp.SetValue(entityToInsert, Convert.ChangeType(id, idp.PropertyType), null);
 
         return id;
@@ -332,7 +324,7 @@ public partial class SqlServerAdapter
 
 public partial class SqlCeServerAdapter
 {
-    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var cmd = $"INSERT INTO {tableName} ({columnList}) VALUES ({parameterList})";
         await connection.ExecuteAsync(cmd, entityToInsert, transaction, commandTimeout).ConfigureAwait(false);
@@ -340,11 +332,10 @@ public partial class SqlCeServerAdapter
 
         if (r.First() == null || r.First().id == null) return 0;
         var id = (int)r.First().id;
+        
+        if (!keyProperties.Any()) return id;
 
-        var pi = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!pi.Any()) return id;
-
-        var idp = pi.First();
+        var idp = keyProperties.First().PropertyInfo;
         idp.SetValue(entityToInsert, Convert.ChangeType(id, idp.PropertyType), null);
 
         return id;
@@ -354,7 +345,7 @@ public partial class SqlCeServerAdapter
 public partial class MySqlAdapter
 {
     public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName,
-        string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+        string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var cmd = $"INSERT INTO {tableName} ({columnList}) VALUES ({parameterList})";
         await connection.ExecuteAsync(cmd, entityToInsert, transaction, commandTimeout).ConfigureAwait(false);
@@ -362,10 +353,9 @@ public partial class MySqlAdapter
 
         var id = r.First().id;
         if (id == null) return 0;
-        var pi = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!pi.Any()) return Convert.ToInt32(id);
+        if (!keyProperties.Any()) return Convert.ToInt32(id);
 
-        var idp = pi.First();
+        var idp = keyProperties.First().PropertyInfo;
         idp.SetValue(entityToInsert, Convert.ChangeType(id, idp.PropertyType), null);
 
         return Convert.ToInt32(id);
@@ -374,25 +364,24 @@ public partial class MySqlAdapter
 
 public partial class PostgresAdapter
 { 
-    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var sb = new StringBuilder();
         sb.AppendFormat("INSERT INTO {0} ({1}) VALUES ({2})", tableName, columnList, parameterList);
 
         // If no primary key then safe to assume a join table with not too much data to return
-        var propertyInfos = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!propertyInfos.Any())
+        if (!keyProperties.Any())
             sb.Append(" RETURNING *");
         else
         {
             sb.Append(" RETURNING ");
             bool first = true;
-            foreach (var property in propertyInfos)
+            foreach (var property in keyProperties)
             {
                 if (!first)
                     sb.Append(", ");
                 first = false;
-                sb.Append(property.Name);
+                sb.Append(property.ColumnName);
             }
         }
 
@@ -401,10 +390,10 @@ public partial class PostgresAdapter
         // Return the key by assinging the corresponding property in the object - by product is that it supports compound primary keys
         var id = 0;
         var values = results.First();
-        foreach (var p in propertyInfos)
+        foreach (var p in keyProperties)
         {
-            var value = values[p.Name.ToLower()];
-            p.SetValue(entityToInsert, value, null);
+            var value = values[p.ColumnName.ToLower()];
+            p.PropertyInfo.SetValue(entityToInsert, value, null);
             if (id == 0)
                 id = Convert.ToInt32(value);
         }
@@ -414,16 +403,15 @@ public partial class PostgresAdapter
 
 public partial class SQLiteAdapter
 {
-    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var cmd = $"INSERT INTO {tableName} ({columnList}) VALUES ({parameterList}); SELECT last_insert_rowid() id";
         var multi = await connection.QueryMultipleAsync(cmd, entityToInsert, transaction, commandTimeout);
 
         var id = (int)multi.Read().First().id;
-        var pi = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!pi.Any()) return id;
+        if (!keyProperties.Any()) return id;
 
-        var idp = pi.First();
+        var idp = keyProperties.First().PropertyInfo;
         idp.SetValue(entityToInsert, Convert.ChangeType(id, idp.PropertyType), null);
 
         return id;

--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -14,9 +14,9 @@ namespace Dapper.Contrib.Extensions
     public static partial class SqlMapperExtensions
     {
         /// <summary>
-        /// Returns a single entity by a single id from table "Ts" asynchronously using .NET 4.5 Task. T must be of interface type. 
+        /// Returns a single entity by a single id from table "Ts" asynchronously using .NET 4.5 Task. T must be of interface type.
         /// Id must be marked with [Key] attribute.
-        /// Created entity is tracked/intercepted for changes and used by the Update() extension. 
+        /// Created entity is tracked/intercepted for changes and used by the Update() extension.
         /// </summary>
         /// <typeparam name="T">Interface type to create and populate</typeparam>
         /// <param name="connection">Open SqlConnection</param>
@@ -33,15 +33,23 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(GetAsync));
                 var name = GetTableName(type);
 
-                var adapter = GetFormatter(connection);
                 var aliasedColumns = new StringBuilder();
-                var allCols = GetAllColumns(type);
-                for (var i=0; i<allCols.Count; i++)
+
+                if(GetPersistentColumns == DefaultGetPersistentColumns)
                 {
-                    var col = allCols[i];
-                    adapter.AppendAliasedColumn(aliasedColumns, col.ColumnName, col.PropertyInfo.Name);
-                    if (i < allCols.Count - 1)
-                        aliasedColumns.Append(",");
+                    aliasedColumns.Append("*");
+                }
+                else
+                {                
+                    var adapter = GetFormatter(connection);
+                    var allCols = GetAllColumns(type);
+                    for (var i=0; i<allCols.Count; i++)
+                    {
+                        var col = allCols[i];
+                        adapter.AppendAliasedColumn(aliasedColumns, col.ColumnName, col.PropertyInfo.Name);
+                        if (i < allCols.Count - 1)
+                            aliasedColumns.Append(",");
+                    }
                 }
 
                 sql = $"select {aliasedColumns} from {name} where {key.ColumnName} = @id";
@@ -73,10 +81,10 @@ namespace Dapper.Contrib.Extensions
         }
 
         /// <summary>
-        /// Returns a list of entites from table "Ts".  
+        /// Returns a list of entites from table "Ts".
         /// Id of T must be marked with [Key] attribute.
         /// Entities created from interfaces are tracked/intercepted for changes and used by the Update() extension
-        /// for optimal performance. 
+        /// for optimal performance.
         /// </summary>
         /// <typeparam name="T">Interface or type to create and populate</typeparam>
         /// <param name="connection">Open SqlConnection</param>
@@ -231,7 +239,7 @@ namespace Dapper.Contrib.Extensions
 
             var sb = new StringBuilder();
             sb.AppendFormat("update {0} set ", name);
-            
+
             var persistentProperties = PersistentPropertiesCache(type);
 
             var adapter = GetFormatter(connection);
@@ -334,7 +342,7 @@ public partial class SqlServerAdapter
         if (first == null || first.id == null) return 0;
 
         var id = (int)first.id;
-        
+
         if (!keyProperties.Any()) return id;
 
         var idp = keyProperties.First().PropertyInfo;
@@ -354,7 +362,7 @@ public partial class SqlCeServerAdapter
 
         if (r.First() == null || r.First().id == null) return 0;
         var id = (int)r.First().id;
-        
+
         if (!keyProperties.Any()) return id;
 
         var idp = keyProperties.First().PropertyInfo;
@@ -385,7 +393,7 @@ public partial class MySqlAdapter
 }
 
 public partial class PostgresAdapter
-{ 
+{
     public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var sb = new StringBuilder();

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -56,8 +56,8 @@ namespace Dapper.Contrib.Extensions
             return new PropertyMap(propInfo.Name, propInfo);
         }
 
-        public static ColumnNameMapperDelegate GetKeyProperties = DefaultGetKeyProperties;
-        private static List<PropertyMap> DefaultGetKeyProperties(Type type)
+        public static ColumnNameMapperDelegate GetKeyColumns = DefaultGetKeyColumns;
+        private static List<PropertyMap> DefaultGetKeyColumns(Type type)
         {
             var allProperties = TypePropertiesCache(type);
             var keyProperties = allProperties.Where(p => p.PropertyInfo.GetCustomAttributes(true)
@@ -92,7 +92,7 @@ namespace Dapper.Contrib.Extensions
                 return pi.ToList();
             }
 
-            var keyProperties = GetKeyProperties(type);
+            var keyProperties = GetKeyColumns(type);
 
             KeyProperties[type.TypeHandle] = keyProperties;
             return keyProperties;
@@ -128,13 +128,13 @@ namespace Dapper.Contrib.Extensions
                 return pis.ToList();
             }
 
-            var properties = GetPersistentProperties(type);
+            var properties = GetPersistentColumns(type);
             PersistentProperties[type.TypeHandle] = properties;
             return properties.ToList();
         }
 
-        public static ColumnNameMapperDelegate GetPersistentProperties = DefaultGetPersistentProperties;
-        private static List<PropertyMap> DefaultGetPersistentProperties(Type type)
+        public static ColumnNameMapperDelegate GetPersistentColumns = DefaultGetPersistentColumns;
+        private static List<PropertyMap> DefaultGetPersistentColumns(Type type)
         {
             var keyProperties = KeyPropertiesCache(type)
                                                 .Where(k => !k.PropertyInfo.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute))

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -33,10 +33,10 @@ namespace Dapper.Contrib.Extensions
         public delegate string GetDatabaseTypeDelegate(IDbConnection connection);
         public delegate string TableNameMapperDelegate(Type type);
 
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> KeyProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>();
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> ExplicitKeyProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>();
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> TypeProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>();
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> ComputedProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>();
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyMap>> KeyProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyMap>>();
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyMap>> TypeProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyMap>>();
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyMap>> ComputedProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyMap>>();
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyMap>> PersistentProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyMap>>();
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> GetQueries = new ConcurrentDictionary<RuntimeTypeHandle, string>();
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> TypeTableName = new ConcurrentDictionary<RuntimeTypeHandle, string>();
 
@@ -51,73 +51,114 @@ namespace Dapper.Contrib.Extensions
                 {"mysqlconnection", new MySqlAdapter()},
             };
 
-        private static List<PropertyInfo> ComputedPropertiesCache(Type type)
+        private static PropertyMap MapProperty(PropertyInfo propInfo)
         {
-            IEnumerable<PropertyInfo> pi;
+            return new PropertyMap(propInfo.Name, propInfo);
+        }
+
+        private static List<PropertyMap> ComputedPropertiesCache(Type type)
+        {
+            IEnumerable<PropertyMap> pi;
             if (ComputedProperties.TryGetValue(type.TypeHandle, out pi))
             {
                 return pi.ToList();
             }
 
-            var computedProperties = TypePropertiesCache(type).Where(p => p.GetCustomAttributes(true).Any(a => a is ComputedAttribute)).ToList();
+            var computedProperties = TypePropertiesCache(type).Where(p => p.PropertyInfo.GetCustomAttributes(true).Any(a => a is ComputedAttribute)).ToList();
 
             ComputedProperties[type.TypeHandle] = computedProperties;
             return computedProperties;
         }
 
-        private static List<PropertyInfo> ExplicitKeyPropertiesCache(Type type)
+        public static Func<Type, List<PropertyMap>> GetKeyProperties;
+        private static List<PropertyMap> DefaultGetKeyProperties(Type type)
         {
-            IEnumerable<PropertyInfo> pi;
-            if (ExplicitKeyProperties.TryGetValue(type.TypeHandle, out pi))
-            {
-                return pi.ToList();
-            }
-
-            var explicitKeyProperties = TypePropertiesCache(type).Where(p => p.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute)).ToList();
-
-            ExplicitKeyProperties[type.TypeHandle] = explicitKeyProperties;
-            return explicitKeyProperties;
-        }
-
-        private static List<PropertyInfo> KeyPropertiesCache(Type type)
-        {
-
-            IEnumerable<PropertyInfo> pi;
-            if (KeyProperties.TryGetValue(type.TypeHandle, out pi))
-            {
-                return pi.ToList();
-            }
-
             var allProperties = TypePropertiesCache(type);
-            var keyProperties = allProperties.Where(p =>
-            {
-                return p.GetCustomAttributes(true).Any(a => a is KeyAttribute);
-            }).ToList();
+            var keyProperties = allProperties.Where(p => p.PropertyInfo.GetCustomAttributes(true)
+                                             .Any(a => a is KeyAttribute))
+                                             .ToList();
 
             if (keyProperties.Count == 0)
             {
-                var idProp = allProperties.FirstOrDefault(p => p.Name.ToLower() == "id");
-                if (idProp != null && !idProp.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute))
+                var idProp = allProperties.FirstOrDefault(p => p.PropertyInfo.Name.ToLower() == "id");
+                if (idProp != null)
                 {
                     keyProperties.Add(idProp);
                 }
             }
 
+            var explicitKeyProperties = TypePropertiesCache(type)
+                                            .Where(p => p.PropertyInfo.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute))
+                                            .ToList();
+
+
+            keyProperties.AddRange(explicitKeyProperties);
+
+            return keyProperties;
+        }
+
+        private static List<PropertyMap> KeyPropertiesCache(Type type)
+        {
+            IEnumerable<PropertyMap> pi;
+            if (KeyProperties.TryGetValue(type.TypeHandle, out pi))
+            {
+                return pi.ToList();
+            }
+
+            var keyProperties = GetKeyProperties(type);
+
             KeyProperties[type.TypeHandle] = keyProperties;
             return keyProperties;
         }
 
-        private static List<PropertyInfo> TypePropertiesCache(Type type)
+        public static Func<Type, List<PropertyMap>> GetAllColumns = DefaultGetAllColumns;
+        private static List<PropertyMap> DefaultGetAllColumns(Type type)
         {
-            IEnumerable<PropertyInfo> pis;
+            return type.GetProperties()
+                       .Where(IsWriteable)
+                       .Select(MapProperty)
+                       .ToList();
+        }
+
+        private static List<PropertyMap> TypePropertiesCache(Type type)
+        {
+            IEnumerable<PropertyMap> pis;
             if (TypeProperties.TryGetValue(type.TypeHandle, out pis))
             {
                 return pis.ToList();
             }
 
-            var properties = type.GetProperties().Where(IsWriteable).ToArray();
+            var properties = GetAllColumns(type);
             TypeProperties[type.TypeHandle] = properties;
             return properties.ToList();
+        }
+
+        private static List<PropertyMap> PersistentPropertiesCache(Type type)
+        {
+            IEnumerable<PropertyMap> pis;
+            if (PersistentProperties.TryGetValue(type.TypeHandle, out pis))
+            {
+                return pis.ToList();
+            }
+
+            var properties = GetPersistentProperties(type);
+            PersistentProperties[type.TypeHandle] = properties;
+            return properties.ToList();
+        }
+
+        public static Func<Type, List<PropertyMap>> GetPersistentProperties;
+        private static List<PropertyMap> DefaultGetPersistentProperties(Type type)
+        {
+            var keyProperties = KeyPropertiesCache(type)
+                                                .Where(k => !k.PropertyInfo.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute))
+                                                .Select(k => k.PropertyInfo);
+
+            var computedProperties = ComputedPropertiesCache(type).Select(p => p.PropertyInfo);
+            var exclusions = keyProperties.Union(computedProperties);
+
+            return TypePropertiesCache(type)
+                                    .Where(t => !exclusions.Contains(t.PropertyInfo))
+                                    .ToList();
         }
 
         private static bool IsWriteable(PropertyInfo pi)
@@ -129,18 +170,17 @@ namespace Dapper.Contrib.Extensions
             return writeAttribute.Write;
         }
 
-        private static PropertyInfo GetSingleKey<T>(string method)
+        private static PropertyMap GetSingleKey<T>(string method)
         {
             var type = typeof (T);
             var keys = KeyPropertiesCache(type);
-            var explicitKeys = ExplicitKeyPropertiesCache(type);
-            var keyCount = keys.Count + explicitKeys.Count;
+            var keyCount = keys.Count;
             if (keyCount > 1)
-                throw new DataException($"{method}<T> only supports an entity with a single [Key] or [ExplicitKey] property");
+                throw new DataException($"{method}<T> only supports an entity with a single key property, as defined by GetKeyProperties. By defualt, this is determined by [Key] or [ExplicitKey] attributes");
             if (keyCount == 0)
-                throw new DataException($"{method}<T> only supports an entity with a [Key] or an [ExplicitKey] property");
+                throw new DataException($"{method}<T> only supports an entity with a key property, as defined by GetKeyProperties. By defualt, this is determined by [Key] or [ExplicitKey] attributes");
 
-            return keys.Any() ? keys.First() : explicitKeys.First();
+            return keys.First();
         }
 
         /// <summary>
@@ -165,7 +205,7 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(Get));
                 var name = GetTableName(type);
 
-                sql = $"select * from {name} where {key.Name} = @id";
+                sql = $"select * from {name} where {key.ColumnName} = @id";
                 GetQueries[type.TypeHandle] = sql;
             }
 
@@ -185,8 +225,8 @@ namespace Dapper.Contrib.Extensions
 
                 foreach (var property in TypePropertiesCache(type))
                 {
-                    var val = res[property.Name];
-                    property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    var val = res[property.ColumnName];
+                    property.PropertyInfo.SetValue(obj, Convert.ChangeType(val, property.PropertyInfo.PropertyType), null);
                 }
 
                 ((IProxy)obj).IsDirty = false;   //reset change tracking and return
@@ -233,8 +273,8 @@ namespace Dapper.Contrib.Extensions
                 var obj = ProxyGenerator.GetInterfaceProxy<T>();
                 foreach (var property in TypePropertiesCache(type))
                 {
-                    var val = res[property.Name];
-                    property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    var val = res[property.ColumnName];
+                    property.PropertyInfo.SetValue(obj, Convert.ChangeType(val, property.PropertyInfo.PropertyType), null);
                 }
                 ((IProxy)obj).IsDirty = false;   //reset change tracking and return
                 list.Add(obj);
@@ -306,27 +346,25 @@ namespace Dapper.Contrib.Extensions
 
             var name = GetTableName(type);
             var sbColumnList = new StringBuilder(null);
-            var allProperties = TypePropertiesCache(type);
             var keyProperties = KeyPropertiesCache(type);
-            var computedProperties = ComputedPropertiesCache(type);
-            var allPropertiesExceptKeyAndComputed = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
+            var persistentProperties = PersistentPropertiesCache(type);
 
             var adapter = GetFormatter(connection);
 
-            for (var i = 0; i < allPropertiesExceptKeyAndComputed.Count; i++)
+            for (var i = 0; i < persistentProperties.Count; i++)
             {
-                var property = allPropertiesExceptKeyAndComputed.ElementAt(i);
-                adapter.AppendColumnName(sbColumnList, property.Name);  //fix for issue #336
-                if (i < allPropertiesExceptKeyAndComputed.Count - 1)
+                var property = persistentProperties.ElementAt(i);
+                adapter.AppendColumnName(sbColumnList, property.ColumnName);  //fix for issue #336
+                if (i < persistentProperties.Count - 1)
                     sbColumnList.Append(", ");
             }
 
             var sbParameterList = new StringBuilder(null);
-            for (var i = 0; i < allPropertiesExceptKeyAndComputed.Count; i++)
+            for (var i = 0; i < persistentProperties.Count; i++)
             {
-                var property = allPropertiesExceptKeyAndComputed.ElementAt(i);
-                sbParameterList.AppendFormat("@{0}", property.Name);
-                if (i < allPropertiesExceptKeyAndComputed.Count - 1)
+                var property = persistentProperties.ElementAt(i);
+                sbParameterList.AppendFormat("@{0}", property.ColumnName);
+                if (i < persistentProperties.Count - 1)
                     sbParameterList.Append(", ");
             }
 
@@ -377,35 +415,32 @@ namespace Dapper.Contrib.Extensions
                 type = type.GetGenericArguments()[0];
             }
 
-            var keyProperties = KeyPropertiesCache(type).ToList();  //added ToList() due to issue #418, must work on a list copy
-            var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
-            if (!keyProperties.Any() && !explicitKeyProperties.Any())
-                throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");
+            var keyProperties = KeyPropertiesCache(type);  //added ToList() due to issue #418, must work on a list copy
+
+            if (!keyProperties.Any())
+                throw new ArgumentException("Entity must have at least one key property, defined by GetKeyProperties. By default, use [Key] or [ExplicitKey] attributes");
 
             var name = GetTableName(type);
 
             var sb = new StringBuilder();
             sb.AppendFormat("update {0} set ", name);
 
-            var allProperties = TypePropertiesCache(type);
-            keyProperties.AddRange(explicitKeyProperties);
-            var computedProperties = ComputedPropertiesCache(type);
-            var nonIdProps = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
+            var persistentProperties = PersistentPropertiesCache(type);
 
-            var adapter = GetFormatter(connection); 
+            var adapter = GetFormatter(connection);
 
-            for (var i = 0; i < nonIdProps.Count; i++)
+            for (var i = 0; i < persistentProperties.Count; i++)
             {
-                var property = nonIdProps.ElementAt(i);
-                adapter.AppendColumnNameEqualsValue(sb, property.Name);  //fix for issue #336
-                if (i < nonIdProps.Count - 1)
+                var property = persistentProperties.ElementAt(i);
+                adapter.AppendColumnNameEqualsValue(sb, property.ColumnName);  //fix for issue #336
+                if (i < persistentProperties.Count - 1)
                     sb.AppendFormat(", ");
             }
             sb.Append(" where ");
             for (var i = 0; i < keyProperties.Count; i++)
             {
                 var property = keyProperties.ElementAt(i);
-                adapter.AppendColumnNameEqualsValue(sb, property.Name);  //fix for issue #336
+                adapter.AppendColumnNameEqualsValue(sb, property.ColumnName);  //fix for issue #336
                 if (i < keyProperties.Count - 1)
                     sb.AppendFormat(" and ");
             }
@@ -438,13 +473,11 @@ namespace Dapper.Contrib.Extensions
                 type = type.GetGenericArguments()[0];
             }
 
-            var keyProperties = KeyPropertiesCache(type).ToList();  //added ToList() due to issue #418, must work on a list copy
-            var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
-            if (!keyProperties.Any() && !explicitKeyProperties.Any())
-                throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");
+            var keyProperties = KeyPropertiesCache(type);
+            if (!keyProperties.Any())
+                throw new ArgumentException("Entity must have at least one key property, defined by GetKeyProperties. By default, use [Key] or [ExplicitKey] attributes");
 
             var name = GetTableName(type);
-            keyProperties.AddRange(explicitKeyProperties);
 
             var sb = new StringBuilder();
             sb.AppendFormat("delete from {0} where ", name);
@@ -454,7 +487,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < keyProperties.Count; i++)
             {
                 var property = keyProperties.ElementAt(i);
-                adapter.AppendColumnNameEqualsValue(sb, property.Name);  //fix for issue #336
+                adapter.AppendColumnNameEqualsValue(sb, property.ColumnName);  //fix for issue #336
                 if (i < keyProperties.Count - 1)
                     sb.AppendFormat(" and ");
             }
@@ -688,7 +721,7 @@ namespace Dapper.Contrib.Extensions
 
 public partial interface ISqlAdapter
 {
-    int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert);
+    int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert);
     
     //new methods for issue #336
     void AppendColumnName(StringBuilder sb, string columnName);
@@ -697,7 +730,7 @@ public partial interface ISqlAdapter
 
 public partial class SqlServerAdapter : ISqlAdapter
 {
-    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var cmd = $"insert into {tableName} ({columnList}) values ({parameterList});select SCOPE_IDENTITY() id";
         var multi = connection.QueryMultiple(cmd, entityToInsert, transaction, commandTimeout);
@@ -706,10 +739,9 @@ public partial class SqlServerAdapter : ISqlAdapter
         if (first == null || first.id == null) return 0;
 
         var id = (int)first.id;
-        var propertyInfos = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!propertyInfos.Any()) return id;
+        if (!keyProperties.Any()) return id;
 
-        var idProperty = propertyInfos.First();
+        var idProperty = keyProperties.First().PropertyInfo;
         idProperty.SetValue(entityToInsert, Convert.ChangeType(id, idProperty.PropertyType), null);
 
         return id;
@@ -728,7 +760,7 @@ public partial class SqlServerAdapter : ISqlAdapter
 
 public partial class SqlCeServerAdapter : ISqlAdapter
 {
-    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var cmd = $"insert into {tableName} ({columnList}) values ({parameterList})";
         connection.Execute(cmd, entityToInsert, transaction, commandTimeout);
@@ -737,10 +769,9 @@ public partial class SqlCeServerAdapter : ISqlAdapter
         if (r.First().id == null) return 0;
         var id = (int) r.First().id;
 
-        var propertyInfos = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!propertyInfos.Any()) return id;
+         if (!keyProperties.Any()) return id;
 
-        var idProperty = propertyInfos.First();
+        var idProperty = keyProperties.First().PropertyInfo;
         idProperty.SetValue(entityToInsert, Convert.ChangeType(id, idProperty.PropertyType), null);
 
         return id;
@@ -759,7 +790,7 @@ public partial class SqlCeServerAdapter : ISqlAdapter
 
 public partial class MySqlAdapter : ISqlAdapter
 {
-    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var cmd = $"insert into {tableName} ({columnList}) values ({parameterList})";
         connection.Execute(cmd, entityToInsert, transaction, commandTimeout);
@@ -767,10 +798,9 @@ public partial class MySqlAdapter : ISqlAdapter
 
         var id = r.First().id;
         if (id == null) return 0;
-        var propertyInfos = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!propertyInfos.Any()) return Convert.ToInt32(id);
+        if (!keyProperties.Any()) return Convert.ToInt32(id);
 
-        var idp = propertyInfos.First();
+        var idp = keyProperties.First().PropertyInfo;
         idp.SetValue(entityToInsert, Convert.ChangeType(id, idp.PropertyType), null);
 
         return Convert.ToInt32(id);
@@ -790,25 +820,24 @@ public partial class MySqlAdapter : ISqlAdapter
 
 public partial class PostgresAdapter : ISqlAdapter
 {
-    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var sb = new StringBuilder();
         sb.AppendFormat("insert into {0} ({1}) values ({2})", tableName, columnList, parameterList);
 
         // If no primary key then safe to assume a join table with not too much data to return
-        var propertyInfos = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!propertyInfos.Any())
+        if (!keyProperties.Any())
             sb.Append(" RETURNING *");
         else
         {
             sb.Append(" RETURNING ");
             var first = true;
-            foreach (var property in propertyInfos)
+            foreach (var property in keyProperties)
             {
                 if (!first)
                     sb.Append(", ");
                 first = false;
-                sb.Append(property.Name);
+                sb.Append(property.ColumnName);
             }
         }
 
@@ -816,10 +845,10 @@ public partial class PostgresAdapter : ISqlAdapter
 
         // Return the key by assinging the corresponding property in the object - by product is that it supports compound primary keys
         var id = 0;
-        foreach (var p in propertyInfos)
+        foreach (var p in keyProperties)
         {
-            var value = ((IDictionary<string, object>)results.First())[p.Name.ToLower()];
-            p.SetValue(entityToInsert, value, null);
+            var value = ((IDictionary<string, object>)results.First())[p.ColumnName.ToLower()];
+            p.PropertyInfo.SetValue(entityToInsert, value, null);
             if (id == 0)
                 id = Convert.ToInt32(value);
         }
@@ -839,16 +868,15 @@ public partial class PostgresAdapter : ISqlAdapter
 
 public partial class SQLiteAdapter : ISqlAdapter
 {
-    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    public int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IList<PropertyMap> keyProperties, object entityToInsert)
     {
         var cmd = $"INSERT INTO {tableName} ({columnList}) VALUES ({parameterList}); SELECT last_insert_rowid() id";
         var multi = connection.QueryMultiple(cmd, entityToInsert, transaction, commandTimeout);
 
         var id = (int)multi.Read().First().id;
-        var propertyInfos = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
-        if (!propertyInfos.Any()) return id;
+        if (!keyProperties.Any()) return id;
 
-        var idProperty = propertyInfos.First();
+        var idProperty = keyProperties.First().PropertyInfo;
         idProperty.SetValue(entityToInsert, Convert.ChangeType(id, idProperty.PropertyType), null);
 
         return id;
@@ -864,3 +892,15 @@ public partial class SQLiteAdapter : ISqlAdapter
         sb.AppendFormat("\"{0}\" = @{1}", columnName, columnName);
     }
 }
+
+public class PropertyMap
+{
+    public PropertyMap(string columnName, PropertyInfo propInfo)
+    {
+        ColumnName = columnName;
+        PropertyInfo = propInfo;
+    }
+    public string ColumnName { get; private set; }
+    public PropertyInfo PropertyInfo { get; private set; }
+}
+

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -195,15 +195,23 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(Get));
                 var name = GetTableName(type);
 
-                var adapter = GetFormatter(connection);
                 var aliasedColumns = new StringBuilder();
-                var allCols = GetAllColumns(type);
-                for (var i=0; i<allCols.Count; i++)
+
+                if(GetPersistentColumns == DefaultGetPersistentColumns)
                 {
-                    var col = allCols[i];
-                    adapter.AppendAliasedColumn(aliasedColumns, col.ColumnName, col.PropertyInfo.Name);
-                    if (i < allCols.Count - 1)
-                        aliasedColumns.Append(",");
+                    aliasedColumns.Append("*");
+                }
+                else
+                {
+                    var adapter = GetFormatter(connection);
+                    var allCols = GetAllColumns(type);
+                    for (var i=0; i<allCols.Count; i++)
+                    {
+                        var col = allCols[i];
+                        adapter.AppendAliasedColumn(aliasedColumns, col.ColumnName, col.PropertyInfo.Name);
+                        if (i < allCols.Count - 1)
+                            aliasedColumns.Append(",");
+                    }
                 }
 
                 sql = $"select {aliasedColumns} from {name} where {key.ColumnName} = @id";

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -192,13 +192,13 @@ namespace Dapper.Tests.Contrib
                     t => t == typeof(StrangelyMappedThing) ? new List<PropertyMap> {idCol, nameCol}
                                                            : origGetAll(t);
 
-                var origGetPersistent = SqlMapperExtensions.GetPersistentProperties;
-                SqlMapperExtensions.GetPersistentProperties =
+                var origGetPersistent = SqlMapperExtensions.GetPersistentColumns;
+                SqlMapperExtensions.GetPersistentColumns =
                     t => t == typeof(StrangelyMappedThing) ? new List<PropertyMap> {idCol, nameCol}
                                                            : origGetPersistent(t);
 
-                var origGetKey = SqlMapperExtensions.GetKeyProperties;
-                SqlMapperExtensions.GetKeyProperties =
+                var origGetKey = SqlMapperExtensions.GetKeyColumns;
+                SqlMapperExtensions.GetKeyColumns =
                     t => t == typeof(StrangelyMappedThing) ? new List<PropertyMap> {idCol}
                                                            : origGetKey(t);
 

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-
+using System.Reflection;
 using Dapper.Contrib.Extensions;
 
 #if !COREFX
@@ -88,6 +88,13 @@ namespace Dapper.Tests.Contrib
         public int Order { get; set; }
     }
 
+    [Table("StrangelyMappedThing")]
+    public class StrangelyMappedThing
+    {
+        public int WeirdId { get; set; }
+        public string WonderfullName { get; set; }
+    }
+
     public abstract partial class TestSuite
     {
         protected static readonly bool IsAppVeyor = Environment.GetEnvironmentVariable("Appveyor")?.ToUpperInvariant() == "TRUE";
@@ -169,6 +176,48 @@ namespace Dapper.Tests.Contrib
                 connection.Delete(o2);
                 o2 = connection.Get<ObjectY>(id);
                 o2.IsNull();
+            }
+        }
+
+        [Fact]
+        public void InsertGetUpdateDeleteWithOverriddenColumnMaps()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                var idCol = new PropertyMap("strangeId", typeof(StrangelyMappedThing).GetProperty("WeirdId"));
+                var nameCol = new PropertyMap("strangeName", typeof(StrangelyMappedThing).GetProperty("WonderfullName"));
+
+                var origGetAll = SqlMapperExtensions.GetAllColumns;
+                SqlMapperExtensions.GetAllColumns =
+                    t => t == typeof(StrangelyMappedThing) ? new List<PropertyMap> {idCol, nameCol}
+                                                           : origGetAll(t);
+
+                var origGetPersistent = SqlMapperExtensions.GetPersistentProperties;
+                SqlMapperExtensions.GetPersistentProperties =
+                    t => t == typeof(StrangelyMappedThing) ? new List<PropertyMap> {idCol, nameCol}
+                                                           : origGetPersistent(t);
+
+                var origGetKey = SqlMapperExtensions.GetKeyProperties;
+                SqlMapperExtensions.GetKeyProperties =
+                    t => t == typeof(StrangelyMappedThing) ? new List<PropertyMap> {idCol}
+                                                           : origGetKey(t);
+
+                const int id = 1;
+                const string wonderfulName = "foo";
+                var o1 = new StrangelyMappedThing {WeirdId = id, WonderfullName = wonderfulName};
+                var originalxCount = connection.Query<int>("Select Count(*) From StrangelyMappedThing").First();
+                connection.Insert(o1);
+                var list1 = connection.Query<StrangelyMappedThing>("select * from StrangelyMappedThing").ToList();
+                list1.Count.IsEqualTo(originalxCount + 1);
+                o1 = connection.Get<StrangelyMappedThing>(id);
+                o1.WeirdId.IsEqualTo(id);
+                o1.WonderfullName = "bar";
+                connection.Update(o1);
+                o1 = connection.Get<StrangelyMappedThing>(id);
+                o1.WonderfullName.IsEqualTo("bar");
+                connection.Delete(o1);
+                o1 = connection.Get<StrangelyMappedThing>(id);
+                o1.IsNull();
             }
         }
         

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -30,7 +30,7 @@ namespace Dapper.Tests.Contrib
         public static string ConnectionString =>
             IsAppVeyor
                 ? @"Server=(local)\SQL2014;Database=tempdb;User ID=sa;Password=Password12!"
-                : $"Data Source=.;Initial Catalog={DbName};Integrated Security=True";
+                : $"Data Source=localhost\\bluezinc;Initial Catalog={DbName};Integrated Security=True";
         public override IDbConnection GetConnection() => new SqlConnection(ConnectionString);
 
         static SqlServerTestSuite()
@@ -56,6 +56,8 @@ namespace Dapper.Tests.Contrib
                 connection.Execute(@"CREATE TABLE ObjectY (ObjectYId int not null, Name nvarchar(100) not null);");
                 dropTable("ObjectZ");
                 connection.Execute(@"CREATE TABLE ObjectZ (Id int not null, Name nvarchar(100) not null);");
+                dropTable("StrangelyMappedThing");
+                connection.Execute(@"CREATE TABLE StrangelyMappedThing (strangeId int not null, strangeName nvarchar(100) not null);");
             }
         }
     }
@@ -104,6 +106,8 @@ namespace Dapper.Tests.Contrib
                     connection.Execute(@"CREATE TABLE ObjectY (ObjectYId int not null, Name nvarchar(100) not null);");
                     dropTable("ObjectZ");
                     connection.Execute(@"CREATE TABLE ObjectZ (Id int not null, Name nvarchar(100) not null);");
+                    dropTable("StrangelyMappedThing");
+                    connection.Execute(@"CREATE TABLE StrangelyMappedThing (strangeId int not null, strangeName nvarchar(100) not null);");
                 }
             }
             catch (MySqlException e)
@@ -145,6 +149,7 @@ namespace Dapper.Tests.Contrib
                 connection.Execute(@"CREATE TABLE ObjectX (ObjectXId nvarchar(100) not null, Name nvarchar(100) not null) ");
                 connection.Execute(@"CREATE TABLE ObjectY (ObjectYId integer not null, Name nvarchar(100) not null) ");
                 connection.Execute(@"CREATE TABLE ObjectZ (Id integer not null, Name nvarchar(100) not null) ");
+                connection.Execute(@"CREATE TABLE StrangelyMappedThing (strangeId int not null, strangeName nvarchar(100) not null);");
             }
         }
     }
@@ -156,7 +161,7 @@ namespace Dapper.Tests.Contrib
         const string FileName = "Test.DB.sdf";
         public static string ConnectionString => $"Data Source={FileName};";
         public override IDbConnection GetConnection() => new SqlCeConnection(ConnectionString);
-            
+
         static SqlCETestSuite()
         {
             if (File.Exists(FileName))
@@ -176,6 +181,7 @@ namespace Dapper.Tests.Contrib
                 connection.Execute(@"CREATE TABLE ObjectX (ObjectXId nvarchar(100) not null, Name nvarchar(100) not null) ");
                 connection.Execute(@"CREATE TABLE ObjectY (ObjectYId int not null, Name nvarchar(100) not null) ");
                 connection.Execute(@"CREATE TABLE ObjectZ (Id int not null, Name nvarchar(100) not null) ");
+                connection.Execute(@"CREATE TABLE StrangelyMappedThing (strangeId int not null, strangeName nvarchar(100) not null);");
             }
             Console.WriteLine("Created database");
         }

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -30,7 +30,7 @@ namespace Dapper.Tests.Contrib
         public static string ConnectionString =>
             IsAppVeyor
                 ? @"Server=(local)\SQL2014;Database=tempdb;User ID=sa;Password=Password12!"
-                : $"Data Source=localhost\\bluezinc;Initial Catalog={DbName};Integrated Security=True";
+                : $"Data Source=.;Initial Catalog={DbName};Integrated Security=True";
         public override IDbConnection GetConnection() => new SqlConnection(ConnectionString);
 
         static SqlServerTestSuite()

--- a/Dapper.Tests.Contrib/project.json
+++ b/Dapper.Tests.Contrib/project.json
@@ -108,9 +108,7 @@
           "version": "1.0.0",
           "type": "platform"
         },
-        "Microsoft.Data.Sqlite": "1.0.0",
-        "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-rc3-*"
+        "Microsoft.Data.Sqlite": "1.0.0"
       }
     }
   }

--- a/Dapper.Tests/Tests.cs
+++ b/Dapper.Tests/Tests.cs
@@ -3316,6 +3316,38 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
         }
 
         [Fact]
+        public void PseudoPositional_CanUseVariable()
+        {
+            using (var connection = ConnectViaOledb())
+            {
+                int id = 42;
+                var row = connection.QuerySingle("declare @id int = ?id?; select @id as [A], @id as [B];", new { id });
+                int a = (int)row.A;
+                int b = (int)row.B;
+                a.IsEqualTo(42);
+                b.IsEqualTo(42);
+            }
+        }
+        [Fact]
+        public void PseudoPositional_CannotUseParameterMultipleTimes()
+        {
+
+            using (var connection = ConnectViaOledb())
+            {
+                try
+                {
+                    int id = 42;
+                    var row = connection.QuerySingle("select ?id? as [A], ?id? as [B];", new { id });
+                    Assert.Fail();
+                }
+                catch (InvalidOperationException ex) when (ex.Message == "When passing parameters by position, each parameter can only be referenced once")
+                {
+                    // that's a win
+                }
+            }
+        }
+
+        [Fact]
         public void PseudoPositionalParameters_ExecSingle()
         {
             using (var connection = ConnectViaOledb())

--- a/Dapper.Tests/project.json
+++ b/Dapper.Tests/project.json
@@ -137,9 +137,7 @@
           "version": "1.0.0",
           "type": "platform"
         },
-        "Microsoft.Data.Sqlite": "1.0.0",
-        "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-rc3-*"
+        "Microsoft.Data.Sqlite": "1.0.0"
       }
     }
   }


### PR DESCRIPTION
This allows us to apply Property -> Column mapping in a pluggable way.

I originally made this pull request, which was too opinionated: https://github.com/StackExchange/dapper-dot-net/pull/376

That previous PR was closed, and batched into: https://github.com/StackExchange/dapper-dot-net/issues/385

I believe that issue 385 is not the correct place for this, as it is talking specifically about making the mapper more pluggable (i.e. Mapping the data from SqlDataReader to a POCO) - which would only cover SELECTs.

 My PR, is more about the generated SQL that is executed, thus covers INSERT, UPDATE, DELETE & SELECT - i.e. the responsibility of Dapper.Contrib

I have implemented in a similar way to `TableNameMapper` .. where the user must override the following delegates:

`GetAllColumns` - returns all mappings for a type
`GetPersistentColumns` - returns writeable (i.e. Insert & update) mappings for a type
`GetKeyColumns` - returns key mappings for a type

This would be a breaking change for anybody who has implemented their own ISqlAdapter, but that is all

I have only tested this for SQL Server
