### PR TITLE
Update readme to remove notice about requiring open connections

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,8 +16,6 @@ It provides 3 helpers:
 Execute a query and map the results to a strongly typed List
 ------------------------------------------------------------
 
-Note: all extension methods assume the connection is already open, they will fail if the connection is closed.
-
 ```csharp
 public static IEnumerable<T> Query<T>(this IDbConnection cnn, string sql, object param = null, SqlTransaction transaction = null, bool buffered = true)
 ```


### PR DESCRIPTION
From https://twitter.com/Nick_Craver/status/815928282310971393, remove the note from the readme that mentions open connections are required for Dapper to function. Maybe this could be edited into something saying that if the connection is closed, Dapper will attempt to reopen it?