### PR TITLE
Fixed test issue in Simple.Data performance test

### DIFF
--- a/Dapper.Tests/PerformanceTests.cs
+++ b/Dapper.Tests/PerformanceTests.cs
@@ -255,7 +255,7 @@ namespace Dapper.Tests
                 Try(() =>
                 {
                     var sdb = Simple.Data.Database.OpenConnection(TestSuite.ConnectionString);
-                    tests.Add(id => sdb.Posts.FindById(id), "Simple.Data");
+                    tests.Add(id => sdb.Posts.FindById(id).FirstOrDefault(), "Simple.Data");
                 }, "Simple.Data");
 #endif
 

--- a/Dapper.Tests/PerformanceTests.cs
+++ b/Dapper.Tests/PerformanceTests.cs
@@ -259,34 +259,6 @@ namespace Dapper.Tests
                 }, "Simple.Data");
 #endif
 
-#if BELGRADE
-
-                Try(() =>
-                {
-                    var query = new Belgrade.SqlClient.SqlDb.QueryMapper(TestSuite.GetOpenConnection());
-                    tests.Add(id => query.ExecuteReader("SELECT TOP 1 * FROM Posts WHERE Id = " + id,
-                        reader =>
-                        {
-                            var post = new Post();
-                            post.Id = reader.GetInt32(0);
-                            post.Text = reader.GetString(1);
-                            post.CreationDate = reader.GetDateTime(2);
-                            post.LastChangeDate = reader.GetDateTime(3);
-
-                            post.Counter1 = reader.IsDBNull(4) ? null : (int?)reader.GetInt32(4);
-                            post.Counter2 = reader.IsDBNull(5) ? null : (int?)reader.GetInt32(5);
-                            post.Counter3 = reader.IsDBNull(6) ? null : (int?)reader.GetInt32(6);
-                            post.Counter4 = reader.IsDBNull(7) ? null : (int?)reader.GetInt32(7);
-                            post.Counter5 = reader.IsDBNull(8) ? null : (int?)reader.GetInt32(8);
-                            post.Counter6 = reader.IsDBNull(9) ? null : (int?)reader.GetInt32(9);
-                            post.Counter7 = reader.IsDBNull(10) ? null : (int?)reader.GetInt32(10);
-                            post.Counter8 = reader.IsDBNull(11) ? null : (int?)reader.GetInt32(11);
-                            post.Counter9 = reader.IsDBNull(12) ? null : (int?)reader.GetInt32(12);
-                        }), "Belgrade Sql Client");
-                }, "Belgrade Sql Client");
-
-#endif
-
 #if SUSANOO
                 //Susanoo
                 var susanooDb = new DatabaseManager("Smackdown.Properties.Settings.tempdbConnectionString");

--- a/Dapper.Tests/project.json
+++ b/Dapper.Tests/project.json
@@ -23,8 +23,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "Belgrade.Sql.Client": "0.6.2"
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "buildOptions": {
     "warningsAsErrors": true,
@@ -92,8 +91,7 @@
           "SOMA",
           "SIMPLEDATA",
           "SQLITE",
-          "XUNIT2",
-          "BELGRADE"
+          "XUNIT2"
         ]
       },
       "frameworkAssemblies": {
@@ -132,7 +130,7 @@
         "dnxcore50"
       ],
       "buildOptions": {
-        "define": [ "ASYNC", "COREFX", "XUNIT2", "SQLITE","BELGRADE" ]
+        "define": [ "ASYNC", "COREFX", "XUNIT2", "SQLITE" ]
       },
       "dependencies": {
         "Microsoft.NETCore.App": {


### PR DESCRIPTION
Due to the missing FirstOrDefault() in Simple.Data, performance results for this library were too high because nothing was actually loaded (it was much better even that hand coded data reader). I have added FirstOrDefault to fetch row from the database, so the current results are:

Running 500 iterations that load up a post entity

Running...
hand coded took 122ms
Mapper QueryFirstOrDefault took 125ms
Dynamic Mapper Query (buffered) took 130ms
Dynamic Massive ORM Query took 140ms
Dapper.Contrib took 147ms
DataTable via IDataReader.GetValues took 157ms
Mapper Query (buffered) took 160ms
Linq 2 SQL Compiled took 168ms
Mapper Query (non-buffered) took 179ms
Dynamic Mapper Query (non-buffered) took 195ms
Dynamic Mapper QueryQueryFirstOrDefault took 198ms
Entity framework SqlQuery took 202ms
Linq 2 SQL ExecuteQuery took 302ms
Entity framework No Tracking took 365ms
Entity framework took 378ms
Simple.Data took 767ms
Linq 2 SQL took 905ms
Press any key to continue . . .