### PR TITLE
Removed dependency on dotnet sdk version 1.0.0-preview2-003121

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,4 @@
 {
-  "sdk": {
-    "version": "1.0.0-preview2-003121"
-  },
   "projects": [
     "Dapper",
     "Dapper.EntityFramework",


### PR DESCRIPTION
This is proposed fix for https://github.com/StackExchange/Dapper/issues/725

On the machine with dotnet version 1.0.0-preview2-003156, I'm getting he following error when I open the solution file:

> The project is configured to use .NET Core SDK version 1.0.0-preview2-003121 which is not installed under the path C:\Program Files\dotnet. These components are required to build and run this project.

I have removed sdk version from global.js file and everything works fine. Is there some reason why is the solution bound to this version? I would propose to remove this.