### PR TITLE
Fix handling of empty table-valued parameters for SqlDataRecord.

### DIFF
--- a/Dapper/SqlDataRecordListTVPParameter.cs
+++ b/Dapper/SqlDataRecordListTVPParameter.cs
@@ -32,7 +32,7 @@ namespace Dapper
 
         internal static void Set(IDbDataParameter parameter, IEnumerable<Microsoft.SqlServer.Server.SqlDataRecord> data, string typeName)
         {
-            parameter.Value = (object)data ?? DBNull.Value;
+            parameter.Value = (object)data;
             if (parameter is System.Data.SqlClient.SqlParameter sqlParam)
             {
                 sqlParam.SqlDbType = SqlDbType.Structured;

--- a/Dapper/SqlDataRecordListTVPParameter.cs
+++ b/Dapper/SqlDataRecordListTVPParameter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 
 namespace Dapper
 {
@@ -32,7 +33,7 @@ namespace Dapper
 
         internal static void Set(IDbDataParameter parameter, IEnumerable<Microsoft.SqlServer.Server.SqlDataRecord> data, string typeName)
         {
-            parameter.Value = (object)data;
+            parameter.Value = data != null && data.Any() ? data : null;
             if (parameter is System.Data.SqlClient.SqlParameter sqlParam)
             {
                 sqlParam.SqlDbType = SqlDbType.Structured;


### PR DESCRIPTION
Hello,

When using Dapper's support for enumerables of SqlDataRecord, we encountered a bug where DBNulls were incorrectly passed for SQL Server Table Valued Parameters.
This generates an error, as SQL "NULL" is not an allowed value for table types in SQL Server. Since enumerabels of zero elements are forbidden by the SqlClient driver, the only valid value to use for expressing an empty table is the C# null value, which was previously converted to DBNull.Value by Dapper.

This PR at least partially fixes issue #649, by allowing developers to explicitly pass null as the value for TVPs in Dapper.