### PR TITLE
Correct minor typographical error in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -240,7 +240,7 @@ new {A = 1, B = "b"} // A will be mapped to the param @A, B to the param @B
 
 List Support
 ------------
-Dapper allow you to pass in IEnumerable<int> and will automatically parameterize your query.
+Dapper allows you to pass in IEnumerable<int> and will automatically parameterize your query.
 
 For example:
 


### PR DESCRIPTION
Under the `List Support` section, the sentence opens with `Dapper allow you`, which should instead be `Dapper allows you`. This PR will correct this mistake, restoring balance to the universe.

After originally spotting this, the most minor of mistakes, I decided to leave it and move on with my life, since it likely effected nobody. Four hours passed and the thought that it existed unchecked had fully manifested itself within my subconscious and I was no longer able to continue with my existence knowing that I had seen this mistake and not exercised my power to correct it.

Thank you, and sorry.