### PR TITLE
-  SqlMapper: MultiMapImpl: Only yield results when a mapper returns a value

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1316,7 +1316,8 @@ namespace Dapper
                 {
                     while (reader.Read())
                     {
-                        yield return mapIt(reader);
+                        var result = mapIt(reader);
+                       if (result != null) yield return result;
                     }
                     if(finalize)
                     {
@@ -1385,7 +1386,8 @@ namespace Dapper
                 {
                     while (reader.Read())
                     {
-                        yield return mapIt(reader);
+                        var result = mapIt(reader);
+                        if (result != null) yield return result;
                     }
                     if (finalize)
                     {


### PR DESCRIPTION
There is a use case where you may want to omit rows from a query during mapping. Especially in one-to-many situations.

This change allows you to return null in a map function, and not have dapper yield those nulls out into the resulting IEnumerable<>

I couldn't test the unit test, as I don't have a local copy of MSSQL. Here's hoping the automated builds show up if I bungled it for this fork.