### PR TITLE
Fix MySQL tests

### DIFF
--- a/Dapper.Tests/Providers/MySQLTests.cs
+++ b/Dapper.Tests/Providers/MySQLTests.cs
@@ -26,9 +26,9 @@ namespace Dapper.Tests
         [FactMySql]
         public void DapperEnumValue_Mysql()
         {
-            using (var connection = GetMySqlConnection())
+            using (var conn = GetMySqlConnection())
             {
-                Common.DapperEnumValue(connection);
+                Common.DapperEnumValue(conn);
             }
         }
 
@@ -77,7 +77,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
         {
             using (var conn = GetMySqlConnection(true, false, false))
             {
-                Common.TestDateTime(connection);
+                Common.TestDateTime(conn);
             }
         }
 
@@ -86,7 +86,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
         {
             using (var conn = GetMySqlConnection(true, true, false))
             {
-                Common.TestDateTime(connection);
+                Common.TestDateTime(conn);
             }
         }
 
@@ -95,7 +95,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
         {
             using (var conn = GetMySqlConnection(true, false, true))
             {
-                Common.TestDateTime(connection);
+                Common.TestDateTime(conn);
             }
         }
 
@@ -104,7 +104,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
         {
             using (var conn = GetMySqlConnection(true, true, true))
             {
-                Common.TestDateTime(connection);
+                Common.TestDateTime(conn);
             }
         }
 

--- a/Dapper.Tests/Providers/MySQLTests.cs
+++ b/Dapper.Tests/Providers/MySQLTests.cs
@@ -90,7 +90,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
             }
         }
 
-        [FactMySql]
+        [FactMySql(Skip = "See https://github.com/StackExchange/Dapper/issues/295, AllowZeroDateTime=True is not supported")]
         public void Issue295_NullableDateTime_MySql_AllowZeroDatetime()
         {
             using (var conn = GetMySqlConnection(true, false, true))
@@ -99,7 +99,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
             }
         }
 
-        [FactMySql]
+        [FactMySql(Skip = "See https://github.com/StackExchange/Dapper/issues/295, AllowZeroDateTime=True is not supported")]
         public void Issue295_NullableDateTime_MySql_ConvertAllowZeroDatetime()
         {
             using (var conn = GetMySqlConnection(true, true, true))

--- a/Dapper.Tests/TestBase.cs
+++ b/Dapper.Tests/TestBase.cs
@@ -78,7 +78,7 @@ namespace Dapper.Tests
 
         public void Dispose()
         {
-            connection?.Dispose();
+            _connection?.Dispose();
         }
     }
 }


### PR DESCRIPTION
The MySQLTests were being run against `TestBase.connection`, which is a `SQLConnection`, not the local variable `conn`, which is the `MySqlConnection`.

Once this was fixed, two tests started failing because #295 (`InvalidCastException` is thrown when `AllowZeroDateTime=True` is present in the MySQL connection string) is still open.

Finally, I added a minor optimisation to not lazily-create `TestBase.connection` in `TestBase.Dispose`; this is primarily useful for the MySQLTests that don't ever need to open a `SQLConnection` to run.