### PR TITLE
when updating and deleting, check if type implements IEnumerable<T> before using generic type as entity's type

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -221,7 +221,15 @@ namespace Dapper.Contrib.Extensions
             }
             else if (type.IsGenericType())
             {
-                type = type.GetGenericArguments()[0];
+                var typeInfo = type.GetTypeInfo();
+                bool implementsGenericIEnumerableOrIsGenericIEnumerable =
+                    typeInfo.ImplementedInterfaces.Any(ti => ti.IsGenericType() && ti.GetGenericTypeDefinition() == typeof(IEnumerable<>)) ||
+                    typeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+                if (implementsGenericIEnumerableOrIsGenericIEnumerable)
+                {
+                    type = type.GetGenericArguments()[0];
+                }
             }
 
             var keyProperties = KeyPropertiesCache(type);
@@ -282,7 +290,15 @@ namespace Dapper.Contrib.Extensions
             }
             else if (type.IsGenericType())
             {
-                type = type.GetGenericArguments()[0];
+                var typeInfo = type.GetTypeInfo();
+                bool implementsGenericIEnumerableOrIsGenericIEnumerable =
+                    typeInfo.ImplementedInterfaces.Any(ti => ti.IsGenericType() && ti.GetGenericTypeDefinition() == typeof(IEnumerable<>)) ||
+                    typeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+                if (implementsGenericIEnumerableOrIsGenericIEnumerable)
+                {
+                    type = type.GetGenericArguments()[0];
+                }
             }
 
             var keyProperties = KeyPropertiesCache(type);

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -415,7 +415,15 @@ namespace Dapper.Contrib.Extensions
             }
             else if (type.IsGenericType())
             {
-                type = type.GetGenericArguments()[0];
+                var typeInfo = type.GetTypeInfo();
+                bool implementsGenericIEnumerableOrIsGenericIEnumerable =
+                    typeInfo.ImplementedInterfaces.Any(ti => ti.IsGenericType() && ti.GetGenericTypeDefinition() == typeof(IEnumerable<>)) ||
+                    typeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+                if (implementsGenericIEnumerableOrIsGenericIEnumerable)
+                {
+                    type = type.GetGenericArguments()[0];
+                }
             }
 
             var keyProperties = KeyPropertiesCache(type).ToList();  //added ToList() due to issue #418, must work on a list copy
@@ -476,7 +484,15 @@ namespace Dapper.Contrib.Extensions
             }
             else if (type.IsGenericType())
             {
-                type = type.GetGenericArguments()[0];
+                var typeInfo = type.GetTypeInfo();
+                bool implementsGenericIEnumerableOrIsGenericIEnumerable =
+                    typeInfo.ImplementedInterfaces.Any(ti => ti.IsGenericType() && ti.GetGenericTypeDefinition() == typeof(IEnumerable<>)) ||
+                    typeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+                if (implementsGenericIEnumerableOrIsGenericIEnumerable)
+                {
+                    type = type.GetGenericArguments()[0];
+                }
             }
 
             var keyProperties = KeyPropertiesCache(type).ToList();  //added ToList() due to issue #418, must work on a list copy

--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -46,6 +46,43 @@ namespace Dapper.Tests.Contrib
             }
         }
 
+        [Fact]
+        public async Task TypeWithGenericParameterCanBeUpdatedAsync()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                var objectToInsert = new GenericType<string>
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = "something"
+                };
+                await connection.InsertAsync(objectToInsert);
+
+                objectToInsert.Name = "somethingelse";
+                await connection.UpdateAsync(objectToInsert);
+
+                var updatedObject = connection.Get<GenericType<string>>(objectToInsert.Id);
+                Assert.Equal(objectToInsert.Name, updatedObject.Name);
+            }
+        }
+
+        [Fact]
+        public async Task TypeWithGenericParameterCanBeDeletedAsync()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                var objectToInsert = new GenericType<string>
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = "something"
+                };
+                await connection.InsertAsync(objectToInsert);
+
+                bool deleted = await connection.DeleteAsync(objectToInsert);
+                Assert.True(deleted);
+            }
+        }
+
         /// <summary>
         /// Tests for issue #351 
         /// </summary>
@@ -264,6 +301,12 @@ namespace Dapper.Tests.Contrib
         }
 
         [Fact]
+        public async Task UpdateEnumerableAsync()
+        {
+            await UpdateHelperAsync(src => src.AsEnumerable()).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task UpdateArrayAsync()
         {
             await UpdateHelperAsync(src => src.ToArray()).ConfigureAwait(false);
@@ -300,6 +343,12 @@ namespace Dapper.Tests.Contrib
                 var name = connection.Query<User>("select * from Users").First().Name;
                 Assert.Contains("updated", name);
             }
+        }
+
+        [Fact]
+        public async Task DeleteEnumerableAsync()
+        {
+            await DeleteHelperAsync(src => src.AsEnumerable()).ConfigureAwait(false);
         }
 
         [Fact]

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -155,6 +155,43 @@ namespace Dapper.Tests.Contrib
         }
 
         [Fact]
+        public void TypeWithGenericParameterCanBeUpdated()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                var objectToInsert = new GenericType<string>
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = "something"
+                };
+                connection.Insert(objectToInsert);
+
+                objectToInsert.Name = "somethingelse";
+                connection.Update(objectToInsert);
+
+                var updatedObject = connection.Get<GenericType<string>>(objectToInsert.Id);
+                Assert.Equal(objectToInsert.Name, updatedObject.Name);
+            }
+        }
+
+        [Fact]
+        public void TypeWithGenericParameterCanBeDeleted()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                var objectToInsert = new GenericType<string>
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = "something"
+                };
+                connection.Insert(objectToInsert);
+
+                bool deleted = connection.Delete(objectToInsert);
+                Assert.True(deleted);
+            }
+        }
+
+        [Fact]
         public void Issue418()
         {
             using (var connection = GetOpenConnection())
@@ -363,6 +400,12 @@ namespace Dapper.Tests.Contrib
         }
 
         [Fact]
+        public void UpdateEnumerable()
+        {
+            UpdateHelper(src => src.AsEnumerable());
+        }
+
+        [Fact]
         public void UpdateArray()
         {
             UpdateHelper(src => src.ToArray());
@@ -399,6 +442,12 @@ namespace Dapper.Tests.Contrib
                 var name = connection.Query<User>("select * from Users").First().Name;
                 Assert.Contains("updated", name);
             }
+        }
+
+        [Fact]
+        public void DeleteEnumerable()
+        {
+            DeleteHelper(src => src.AsEnumerable());
         }
 
         [Fact]


### PR DESCRIPTION
This is a follow-up to PR #880. I didn't know the same issue affects Update and Delete. 

I'm sorry.