### PR TITLE
Fix case sensitive problem of key properties during insert on PostgresSQL

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -965,7 +965,7 @@ public partial class PostgresAdapter : ISqlAdapter
                 if (!first)
                     sb.Append(", ");
                 first = false;
-                sb.Append(property.Name);
+                sb.AppendFormat("\"{0}\"", property.Name);
             }
         }
 
@@ -975,7 +975,7 @@ public partial class PostgresAdapter : ISqlAdapter
         var id = 0;
         foreach (var p in propertyInfos)
         {
-            var value = ((IDictionary<string, object>)results[0])[p.Name.ToLower()];
+            var value = ((IDictionary<string, object>)results[0])[p.Name];
             p.SetValue(entityToInsert, value, null);
             if (id == 0)
                 id = Convert.ToInt32(value);


### PR DESCRIPTION
Without quote on key column, it will be treated as lower case in case of Postgres.
So, I add double quote to column names and remove ToLower() call in order to use camel spelling in both of code and databse.