### PR TITLE
Use the instance itself instead of T.

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -187,7 +187,7 @@ namespace Dapper.Contrib.Extensions
                 return false;
             }
 
-            var type = typeof(T);
+            var type = entityToUpdate.GetType();
 
             if (type.IsArray)
             {


### PR DESCRIPTION
If the general interface is used for the entities the Key attribute cannot be found.  
For example:
```
public interface IEntity
 {  }

public class Foo:IEntity{
public int Id{get;set;}
public string Name{get;set;
}
```