### PR TITLE
Change to GetAll to allow the usage of a nullable type in T when T is an interface… #933

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -50,7 +50,16 @@ namespace Dapper.Contrib.Extensions
             foreach (var property in TypePropertiesCache(type))
             {
                 var val = res[property.Name];
-                property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                if (val == null) continue;
+                if (property.PropertyType.IsGenericType() && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    var genericType = Nullable.GetUnderlyingType(property.PropertyType);
+                    if (genericType != null) property.SetValue(obj, Convert.ChangeType(val, genericType), null);
+                }
+                else
+                {
+                    property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                }
             }
 
             ((IProxy)obj).IsDirty = false;   //reset change tracking and return
@@ -100,7 +109,16 @@ namespace Dapper.Contrib.Extensions
                 foreach (var property in TypePropertiesCache(type))
                 {
                     var val = res[property.Name];
-                    property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    if (val == null) continue;
+                    if (property.PropertyType.IsGenericType() && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        var genericType = Nullable.GetUnderlyingType(property.PropertyType);
+                        if (genericType != null) property.SetValue(obj, Convert.ChangeType(val, genericType), null);
+                    }
+                    else
+                    {
+                        property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    }
                 }
                 ((IProxy)obj).IsDirty = false;   //reset change tracking and return
                 list.Add(obj);

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -249,9 +249,9 @@ namespace Dapper.Contrib.Extensions
                 foreach (var property in TypePropertiesCache(type))
                 {
                     var val = res[property.Name];
+                    if (val == null) continue;
                     if (property.PropertyType.IsGenericType() && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
                     {
-                        if (val == null) continue;
                         var genericType = property.PropertyType.GetGenericArguments()[0];
                         property.SetValue(obj, Convert.ChangeType(val, genericType), null);
                     }

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -249,7 +249,16 @@ namespace Dapper.Contrib.Extensions
                 foreach (var property in TypePropertiesCache(type))
                 {
                     var val = res[property.Name];
-                    property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    if (property.PropertyType.IsGenericType() && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        if (val == null) continue;
+                        var genericType = property.PropertyType.GetGenericArguments()[0];
+                        property.SetValue(obj, Convert.ChangeType(val, genericType), null);
+                    }
+                    else
+                    {
+                        property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    }
                 }
                 ((IProxy)obj).IsDirty = false;   //reset change tracking and return
                 list.Add(obj);

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -202,7 +202,16 @@ namespace Dapper.Contrib.Extensions
                 foreach (var property in TypePropertiesCache(type))
                 {
                     var val = res[property.Name];
-                    property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    if (val == null) continue;
+                    if (property.PropertyType.IsGenericType() && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        var genericType = property.PropertyType.GetGenericArguments()[0];
+                        property.SetValue(obj, Convert.ChangeType(val, genericType), null);
+                    }
+                    else
+                    {
+                        property.SetValue(obj, Convert.ChangeType(val, property.PropertyType), null);
+                    }
                 }
 
                 ((IProxy)obj).IsDirty = false;   //reset change tracking and return

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -205,8 +205,8 @@ namespace Dapper.Contrib.Extensions
                     if (val == null) continue;
                     if (property.PropertyType.IsGenericType() && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
                     {
-                        var genericType = property.PropertyType.GetGenericArguments()[0];
-                        property.SetValue(obj, Convert.ChangeType(val, genericType), null);
+                        var genericType = Nullable.GetUnderlyingType(property.PropertyType);
+                        if (genericType != null) property.SetValue(obj, Convert.ChangeType(val, genericType), null);
                     }
                     else
                     {
@@ -261,8 +261,8 @@ namespace Dapper.Contrib.Extensions
                     if (val == null) continue;
                     if (property.PropertyType.IsGenericType() && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
                     {
-                        var genericType = property.PropertyType.GetGenericArguments()[0];
-                        property.SetValue(obj, Convert.ChangeType(val, genericType), null);
+                        var genericType = Nullable.GetUnderlyingType(property.PropertyType);
+                        if (genericType != null) property.SetValue(obj, Convert.ChangeType(val, genericType), null);
                     }
                     else
                     {

--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -356,6 +356,31 @@ namespace Dapper.Tests.Contrib
         }
 
         [Fact]
+        public async void GetAsyncAndGetAllAsyncWithNullableValues()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                var id1 = connection.Insert(new UserWithNullableDob { Name = "Jackson", Dob = new DateTime(2011, 07, 14) });
+                var id2 = connection.Insert(new UserWithNullableDob { Name = "Geoffrey", Dob = null });
+
+                var user1 = await connection.GetAsync<IUserWithNullableDob>(id1);
+                Assert.Equal("Jackson", user1.Name);
+                Assert.Equal(new DateTime(2011, 07, 14), user1.Dob.Value);
+
+                var user2 = await connection.GetAsync<IUserWithNullableDob>(id2);
+                Assert.Equal("Geoffrey", user2.Name);
+                Assert.True(user2.Dob == null);
+
+                var users = await connection.GetAllAsync<IUserWithNullableDob>();
+                var usersList = users.ToList();
+                Assert.Equal("Jackson", usersList[0].Name);
+                Assert.Equal(new DateTime(2011, 07, 14), usersList[0].Dob.Value);
+                Assert.Equal("Geoffrey", usersList[1].Name);
+                Assert.True(usersList[1].Dob == null);
+            }
+        }
+
+        [Fact]
         public async Task InsertFieldWithReservedNameAsync()
         {
             using (var connection = GetOpenConnection())

--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -355,6 +355,9 @@ namespace Dapper.Tests.Contrib
             }
         }
 
+        /// <summary>
+        /// Test for issue #933
+        /// </summary>
         [Fact]
         public async void GetAsyncAndGetAllAsyncWithNullableValues()
         {
@@ -363,15 +366,15 @@ namespace Dapper.Tests.Contrib
                 var id1 = connection.Insert(new UserWithNullableDob { Name = "Jackson", Dob = new DateTime(2011, 07, 14) });
                 var id2 = connection.Insert(new UserWithNullableDob { Name = "Geoffrey", Dob = null });
 
-                var user1 = await connection.GetAsync<IUserWithNullableDob>(id1);
+                var user1 = await connection.GetAsync<IUserWithNullableDob>(id1).ConfigureAwait(false);
                 Assert.Equal("Jackson", user1.Name);
                 Assert.Equal(new DateTime(2011, 07, 14), user1.Dob.Value);
 
-                var user2 = await connection.GetAsync<IUserWithNullableDob>(id2);
+                var user2 = await connection.GetAsync<IUserWithNullableDob>(id2).ConfigureAwait(false);
                 Assert.Equal("Geoffrey", user2.Name);
                 Assert.True(user2.Dob == null);
 
-                var users = await connection.GetAllAsync<IUserWithNullableDob>();
+                var users = await connection.GetAllAsync<IUserWithNullableDob>().ConfigureAwait(false);
                 var usersList = users.ToList();
                 Assert.Equal("Jackson", usersList[0].Name);
                 Assert.Equal(new DateTime(2011, 07, 14), usersList[0].Dob.Value);

--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -363,23 +363,19 @@ namespace Dapper.Tests.Contrib
         {
             using (var connection = GetOpenConnection())
             {
-                var id1 = connection.Insert(new UserWithNullableDob { Name = "Jackson", Dob = new DateTime(2011, 07, 14) });
-                var id2 = connection.Insert(new UserWithNullableDob { Name = "Geoffrey", Dob = null });
+                var id1 = connection.Insert(new NullableDate { DateValue = new DateTime(2011, 07, 14) });
+                var id2 = connection.Insert(new NullableDate { DateValue = null });
 
-                var user1 = await connection.GetAsync<IUserWithNullableDob>(id1).ConfigureAwait(false);
-                Assert.Equal("Jackson", user1.Name);
-                Assert.Equal(new DateTime(2011, 07, 14), user1.Dob.Value);
+                var value1 = await connection.GetAsync<IUserWithNullableDob>(id1).ConfigureAwait(false);
+                Assert.Equal(new DateTime(2011, 07, 14), value1.DateValue.Value);
 
-                var user2 = await connection.GetAsync<IUserWithNullableDob>(id2).ConfigureAwait(false);
-                Assert.Equal("Geoffrey", user2.Name);
-                Assert.True(user2.Dob == null);
+                var value2 = await connection.GetAsync<IUserWithNullableDob>(id2).ConfigureAwait(false);
+                Assert.True(value2.DateValue == null);
 
-                var users = await connection.GetAllAsync<IUserWithNullableDob>().ConfigureAwait(false);
-                var usersList = users.ToList();
-                Assert.Equal("Jackson", usersList[0].Name);
-                Assert.Equal(new DateTime(2011, 07, 14), usersList[0].Dob.Value);
-                Assert.Equal("Geoffrey", usersList[1].Name);
-                Assert.True(usersList[1].Dob == null);
+                var value3 = await connection.GetAllAsync<IUserWithNullableDob>().ConfigureAwait(false);
+                var valuesList = value3.ToList();
+                Assert.Equal(new DateTime(2011, 07, 14), valuesList[0].DateValue.Value);
+                Assert.True(valuesList[1].DateValue == null);
             }
         }
 

--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -366,13 +366,13 @@ namespace Dapper.Tests.Contrib
                 var id1 = connection.Insert(new NullableDate { DateValue = new DateTime(2011, 07, 14) });
                 var id2 = connection.Insert(new NullableDate { DateValue = null });
 
-                var value1 = await connection.GetAsync<IUserWithNullableDob>(id1).ConfigureAwait(false);
+                var value1 = await connection.GetAsync<INullableDate>(id1).ConfigureAwait(false);
                 Assert.Equal(new DateTime(2011, 07, 14), value1.DateValue.Value);
 
-                var value2 = await connection.GetAsync<IUserWithNullableDob>(id2).ConfigureAwait(false);
+                var value2 = await connection.GetAsync<INullableDate>(id2).ConfigureAwait(false);
                 Assert.True(value2.DateValue == null);
 
-                var value3 = await connection.GetAllAsync<IUserWithNullableDob>().ConfigureAwait(false);
+                var value3 = await connection.GetAllAsync<INullableDate>().ConfigureAwait(false);
                 var valuesList = value3.ToList();
                 Assert.Equal(new DateTime(2011, 07, 14), valuesList[0].DateValue.Value);
                 Assert.True(valuesList[1].DateValue == null);

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -558,6 +558,9 @@ namespace Dapper.Tests.Contrib
             }
         }
 
+        /// <summary>
+        /// Test for issue #933
+        /// </summary>
         [Fact]
         public void GetAndGetAllWithNullableValues()
         {

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -57,15 +57,13 @@ namespace Dapper.Tests.Contrib
     {
         [Key]
         int Id { get; set; }
-        string Name { get; set; }
-        DateTime? Dob { get; set; }
+        DateTime? DateValue { get; set; }
     }
 
-    public class UserWithNullableDob : IUserWithNullableDob
+    public class NullableDate : IUserWithNullableDob
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public DateTime? Dob { get; set; }
+        public DateTime? DateValue { get; set; }
     }
 
     public class Person
@@ -566,22 +564,18 @@ namespace Dapper.Tests.Contrib
         {
             using (var connection = GetOpenConnection())
             {
-                var id1 = connection.Insert(new UserWithNullableDob { Name = "Jackson", Dob = new DateTime(2011, 07, 14) });
-                var id2 = connection.Insert(new UserWithNullableDob { Name = "Geoffrey", Dob = null });
+                var id1 = connection.Insert(new NullableDate { DateValue = new DateTime(2011, 07, 14) });
+                var id2 = connection.Insert(new NullableDate { DateValue = null });
 
-                var user1 = connection.Get<IUserWithNullableDob>(id1);
-                Assert.Equal("Jackson", user1.Name);
-                Assert.Equal(new DateTime(2011, 07, 14), user1.Dob.Value);
+                var value1 = connection.Get<IUserWithNullableDob>(id1);
+                Assert.Equal(new DateTime(2011, 07, 14), value1.DateValue.Value);
 
-                var user2 = connection.Get<IUserWithNullableDob>(id2);
-                Assert.Equal("Geoffrey", user2.Name);
-                Assert.True(user2.Dob == null);
+                var value2 = connection.Get<IUserWithNullableDob>(id2);
+                Assert.True(value2.DateValue == null);
 
-                var users = connection.GetAll<IUserWithNullableDob>().ToList();
-                Assert.Equal("Jackson", users[0].Name);
-                Assert.Equal(new DateTime(2011, 07, 14), users[0].Dob.Value);
-                Assert.Equal("Geoffrey", users[1].Name);
-                Assert.True(users[1].Dob == null);
+                var value3 = connection.GetAll<IUserWithNullableDob>().ToList();
+                Assert.Equal(new DateTime(2011, 07, 14), value3[0].DateValue.Value);
+                Assert.True(value3[1].DateValue == null);
             }
         }
 

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -53,6 +53,21 @@ namespace Dapper.Tests.Contrib
         public int Age { get; set; }
     }
 
+    public interface IUserWithNullableDob
+    {
+        [Key]
+        int Id { get; set; }
+        string Name { get; set; }
+        DateTime? Dob { get; set; }
+    }
+
+    public class UserWithNullableDob : IUserWithNullableDob
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public DateTime? Dob { get; set; }
+    }
+
     public class Person
     {
         public int Id { get; set; }
@@ -540,6 +555,30 @@ namespace Dapper.Tests.Contrib
                 Assert.Equal(iusers.Count, numberOfEntities);
                 for (var i = 0; i < numberOfEntities; i++)
                     Assert.Equal(iusers[i].Age, i);
+            }
+        }
+
+        [Fact]
+        public void GetAndGetAllWithNullableValues()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                var id1 = connection.Insert(new UserWithNullableDob { Name = "Jackson", Dob = new DateTime(2011, 07, 14) });
+                var id2 = connection.Insert(new UserWithNullableDob { Name = "Geoffrey", Dob = null });
+
+                var user1 = connection.Get<IUserWithNullableDob>(id1);
+                Assert.Equal("Jackson", user1.Name);
+                Assert.Equal(new DateTime(2011, 07, 14), user1.Dob.Value);
+
+                var user2 = connection.Get<IUserWithNullableDob>(id2);
+                Assert.Equal("Geoffrey", user2.Name);
+                Assert.True(user2.Dob == null);
+
+                var users = connection.GetAll<IUserWithNullableDob>().ToList();
+                Assert.Equal("Jackson", users[0].Name);
+                Assert.Equal(new DateTime(2011, 07, 14), users[0].Dob.Value);
+                Assert.Equal("Geoffrey", users[1].Name);
+                Assert.True(users[1].Dob == null);
             }
         }
 

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -53,14 +53,14 @@ namespace Dapper.Tests.Contrib
         public int Age { get; set; }
     }
 
-    public interface IUserWithNullableDob
+    public interface INullableDate
     {
         [Key]
         int Id { get; set; }
         DateTime? DateValue { get; set; }
     }
 
-    public class NullableDate : IUserWithNullableDob
+    public class NullableDate : INullableDate
     {
         public int Id { get; set; }
         public DateTime? DateValue { get; set; }
@@ -567,13 +567,13 @@ namespace Dapper.Tests.Contrib
                 var id1 = connection.Insert(new NullableDate { DateValue = new DateTime(2011, 07, 14) });
                 var id2 = connection.Insert(new NullableDate { DateValue = null });
 
-                var value1 = connection.Get<IUserWithNullableDob>(id1);
+                var value1 = connection.Get<INullableDate>(id1);
                 Assert.Equal(new DateTime(2011, 07, 14), value1.DateValue.Value);
 
-                var value2 = connection.Get<IUserWithNullableDob>(id2);
+                var value2 = connection.Get<INullableDate>(id2);
                 Assert.True(value2.DateValue == null);
 
-                var value3 = connection.GetAll<IUserWithNullableDob>().ToList();
+                var value3 = connection.GetAll<INullableDate>().ToList();
                 Assert.Equal(new DateTime(2011, 07, 14), value3[0].DateValue.Value);
                 Assert.True(value3[1].DateValue == null);
             }

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -57,6 +57,8 @@ namespace Dapper.Tests.Contrib
                 connection.Execute("CREATE TABLE ObjectZ (Id int not null, Name nvarchar(100) not null);");
                 dropTable("GenericType");
                 connection.Execute("CREATE TABLE GenericType (Id nvarchar(100) not null, Name nvarchar(100) not null);");
+                dropTable("NullableDates");
+                connection.Execute("CREATE TABLE NullableDates (Id int IDENTITY(1,1) not null, DateValue DateTime null);");
             }
         }
     }
@@ -106,6 +108,8 @@ namespace Dapper.Tests.Contrib
                     connection.Execute("CREATE TABLE ObjectZ (Id int not null, Name nvarchar(100) not null);");
                     dropTable("GenericType");
                     connection.Execute("CREATE TABLE GenericType (Id nvarchar(100) not null, Name nvarchar(100) not null);");
+                    dropTable("NullableDates");
+                    connection.Execute("CREATE TABLE NullableDates (Id int not null AUTO_INCREMENT PRIMARY KEY, DateValue DateTime);");
                 }
             }
             catch (MySqlException e)
@@ -142,6 +146,7 @@ namespace Dapper.Tests.Contrib
                 connection.Execute("CREATE TABLE ObjectY (ObjectYId integer not null, Name nvarchar(100) not null) ");
                 connection.Execute("CREATE TABLE ObjectZ (Id integer not null, Name nvarchar(100) not null) ");
                 connection.Execute("CREATE TABLE GenericType (Id nvarchar(100) not null, Name nvarchar(100) not null) ");
+                connection.Execute("CREATE TABLE NullableDates (Id integer primary key autoincrement not null, DateValue DateTime) ");
             }
         }
     }
@@ -173,6 +178,7 @@ namespace Dapper.Tests.Contrib
                 connection.Execute(@"CREATE TABLE ObjectY (ObjectYId int not null, Name nvarchar(100) not null) ");
                 connection.Execute(@"CREATE TABLE ObjectZ (Id int not null, Name nvarchar(100) not null) ");
                 connection.Execute(@"CREATE TABLE GenericType (Id nvarchar(100) not null, Name nvarchar(100) not null) ");
+                connection.Execute(@"CREATE TABLE NullableDates (Id int IDENTITY(1,1) not null, DateValue DateTime null) ");
             }
             Console.WriteLine("Created database");
         }


### PR DESCRIPTION
This pull request is in response to an issue that I raised:

> 'Null object cannot be converted to a value type.' when using nullable type on interface #933

Basically I had DateTime? and was using an interface so that I could use the change tracking in Dapper.Contrib.

Without this modification, the code throws 

> System.InvalidCastException: 'Invalid cast from 'System.String' to 'System.Nullable`1[[System.DateTime, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]'.'

OR

>  'Null object cannot be converted to a value type.' 

depending on whether the value from the (SQLite) database has a value or is null.

My suggested change:
checks for null and if so, continues;
otherwise if the type is nullable, it obtains the underlying property and assigns the value to the underlying property;
otherwise assign the value to the property as per the original code.

