### PR TITLE
fix Insert<T> when T is declared as IEnumerable<T>

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -130,10 +130,18 @@ namespace Dapper.Contrib.Extensions
                 isList = true;
                 type = type.GetElementType();
             }
-            else if (type.IsGenericType() && type.GetTypeInfo().ImplementedInterfaces.Any(ti => ti.IsGenericType() && ti.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
+            else if (type.IsGenericType())
             {
-                isList = true;
-                type = type.GetGenericArguments()[0];
+                var typeInfo = type.GetTypeInfo();
+                bool implementsGenericIEnumerableOrIsGenericIEnumerable =
+                    typeInfo.ImplementedInterfaces.Any(ti => ti.IsGenericType() && ti.GetGenericTypeDefinition() == typeof(IEnumerable<>)) ||
+                    typeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+                if (implementsGenericIEnumerableOrIsGenericIEnumerable)
+                {
+                    isList = true;
+                    type = type.GetGenericArguments()[0];
+                }
             }
 
             var name = GetTableName(type);

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -314,10 +314,18 @@ namespace Dapper.Contrib.Extensions
                 isList = true;
                 type = type.GetElementType();
             }
-            else if (type.IsGenericType() && type.GetTypeInfo().ImplementedInterfaces.Any(ti => ti.IsGenericType() && ti.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
+            else if (type.IsGenericType())
             {
-                isList = true;
-                type = type.GetGenericArguments()[0];
+                var typeInfo = type.GetTypeInfo();
+                bool implementsGenericIEnumerableOrIsGenericIEnumerable =
+                    typeInfo.ImplementedInterfaces.Any(ti => ti.IsGenericType() && ti.GetGenericTypeDefinition() == typeof(IEnumerable<>)) ||
+                    typeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+                if (implementsGenericIEnumerableOrIsGenericIEnumerable)
+                {
+                    isList = true;
+                    type = type.GetGenericArguments()[0];
+                }
             }
 
             var name = GetTableName(type);

--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -226,6 +226,12 @@ namespace Dapper.Tests.Contrib
         }
 
         [Fact]
+        public async Task InsertEnumerableAsync()
+        {
+            await InsertHelperAsync(src => src.AsEnumerable()).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task InsertArrayAsync()
         {
             await InsertHelperAsync(src => src.ToArray()).ConfigureAwait(false);

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -312,6 +312,12 @@ namespace Dapper.Tests.Contrib
         }
 
         [Fact]
+        public void InsertEnumerable()
+        {
+            InsertHelper(src => src.AsEnumerable());
+        }
+
+        [Fact]
         public void InsertArray()
         {
             InsertHelper(src => src.ToArray());


### PR DESCRIPTION
When inserting, when checking if the type implements IEnumerable<>, we weren't checking that the passed type is itself declared as IEnumerable<>. IEnumerable<> doesn't implement IEnumerable<>; it _is_ IEnumerable<>.

This PR changes adds a check for if the type is itself IEnumerable<> in addition to if it implements IEnumerable<>.

This fixes #930.