### PR TITLE
Better error messages for .*Async methods when not using  DbConnection

### DIFF
--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -373,6 +373,36 @@ namespace Dapper
             return task;
         }
 
+        /// <summary>
+        /// Attempts to open a connection asynchronously, with a better error message for unsupported usages.
+        /// </summary>
+        private static Task TryOpenAsync(this IDbConnection cnn, CancellationToken cancel)
+        {
+            if (cnn is DbConnection dbConn)
+            {
+                return dbConn.OpenAsync(cancel);
+            }
+            else
+            {
+                throw new InvalidOperationException("Async operations require use of a DbConnection");
+            }
+        }
+
+        /// <summary>
+        /// Attempts setup a <see cref="DbCommand"/> on a <see cref="DbConnection"/>, with a better error message for unsupported usages.
+        /// </summary>
+        private static DbCommand TrySetupAsyncCommand(this CommandDefinition command, IDbConnection cnn, Action<IDbCommand, object> paramReader)
+        {
+            if (cnn is DbConnection)
+            {
+                return (DbCommand)command.SetupCommand(cnn, paramReader);
+            }
+            else
+            {
+                throw new InvalidOperationException("Async operations require use of a DbConnection");
+            }
+        }
+
         private static async Task<IEnumerable<T>> QueryAsync<T>(this IDbConnection cnn, Type effectiveType, CommandDefinition command)
         {
             object param = command.Parameters;
@@ -380,12 +410,12 @@ namespace Dapper
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
             var cancel = command.CancellationToken;
-            using (var cmd = (DbCommand)command.SetupCommand(cnn, info.ParamReader))
+            using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
             {
                 DbDataReader reader = null;
                 try
                 {
-                    if (wasClosed) await ((DbConnection)cnn).OpenAsync(cancel).ConfigureAwait(false);
+                    if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
                     reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
 
                     var tuple = info.Deserializer;
@@ -444,12 +474,12 @@ namespace Dapper
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
             var cancel = command.CancellationToken;
-            using (var cmd = (DbCommand)command.SetupCommand(cnn, info.ParamReader))
+            using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
             {
                 DbDataReader reader = null;
                 try
                 {
-                    if (wasClosed) await ((DbConnection)cnn).OpenAsync(cancel).ConfigureAwait(false);
+                    if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
                     reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, (row & Row.Single) != 0
                     ? CommandBehavior.SequentialAccess | CommandBehavior.SingleResult // need to allow multiple rows, to check fail condition
                     : CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow, cancel).ConfigureAwait(false);
@@ -546,7 +576,7 @@ namespace Dapper
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
-                if (wasClosed) await ((DbConnection)cnn).OpenAsync(command.CancellationToken).ConfigureAwait(false);
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
 
                 CacheInfo info = null;
                 string masterSql = null;
@@ -562,7 +592,7 @@ namespace Dapper
                             if (isFirst)
                             {
                                 isFirst = false;
-                                cmd = (DbCommand)command.SetupCommand(cnn, null);
+                                cmd = command.TrySetupAsyncCommand(cnn, null);
                                 masterSql = cmd.CommandText;
                                 var identity = new Identity(command.CommandText, cmd.CommandType, cnn, null, obj.GetType(), null);
                                 info = GetCacheInfo(identity, obj, command.AddToCache);
@@ -577,7 +607,7 @@ namespace Dapper
                             }
                             else
                             {
-                                cmd = (DbCommand)command.SetupCommand(cnn, null);
+                                cmd = command.TrySetupAsyncCommand(cnn, null);
                             }
                             info.ParamReader(cmd, obj);
 
@@ -604,7 +634,7 @@ namespace Dapper
                 }
                 else
                 {
-                    using (var cmd = (DbCommand)command.SetupCommand(cnn, null))
+                    using (var cmd = command.TrySetupAsyncCommand(cnn, null))
                     {
                         foreach (var obj in multiExec)
                         {
@@ -640,11 +670,11 @@ namespace Dapper
             var identity = new Identity(command.CommandText, command.CommandType, cnn, null, param?.GetType(), null);
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
-            using (var cmd = (DbCommand)command.SetupCommand(cnn, info.ParamReader))
+            using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
             {
                 try
                 {
-                    if (wasClosed) await ((DbConnection)cnn).OpenAsync(command.CancellationToken).ConfigureAwait(false);
+                    if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
                     var result = await cmd.ExecuteNonQueryAsync(command.CancellationToken).ConfigureAwait(false);
                     command.OnCompleted();
                     return result;
@@ -910,8 +940,8 @@ namespace Dapper
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
-                if (wasClosed) await ((DbConnection)cnn).OpenAsync(command.CancellationToken).ConfigureAwait(false);
-                using (var cmd = (DbCommand)command.SetupCommand(cnn, info.ParamReader))
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
                 using (var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false))
                 {
                     if (!command.Buffered) wasClosed = false; // handing back open reader; rely on command-behavior
@@ -960,8 +990,8 @@ namespace Dapper
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
-                if (wasClosed) await ((DbConnection)cnn).OpenAsync().ConfigureAwait(false);
-                using (var cmd = (DbCommand)command.SetupCommand(cnn, info.ParamReader))
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
                 using (var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false))
                 {
                     var results = MultiMapImpl(null, default(CommandDefinition), types, map, splitOn, reader, identity, true);
@@ -1015,8 +1045,8 @@ namespace Dapper
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
-                if (wasClosed) await ((DbConnection)cnn).OpenAsync(command.CancellationToken).ConfigureAwait(false);
-                cmd = (DbCommand)command.SetupCommand(cnn, info.ParamReader);
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
                 reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess, command.CancellationToken).ConfigureAwait(false);
 
                 var result = new GridReader(cmd, reader, identity, command.Parameters as DynamicParameters, command.AddToCache, command.CancellationToken);
@@ -1108,8 +1138,8 @@ namespace Dapper
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
-                cmd = (DbCommand)command.SetupCommand(cnn, paramReader);
-                if (wasClosed) await ((DbConnection)cnn).OpenAsync(command.CancellationToken).ConfigureAwait(false);
+                cmd = command.TrySetupAsyncCommand(cnn, paramReader);
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
                 var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, commandBehavior, command.CancellationToken).ConfigureAwait(false);
                 wasClosed = false;
                 return reader;
@@ -1182,8 +1212,8 @@ namespace Dapper
             object result;
             try
             {
-                cmd = (DbCommand)command.SetupCommand(cnn, paramReader);
-                if (wasClosed) await ((DbConnection)cnn).OpenAsync(command.CancellationToken).ConfigureAwait(false);
+                cmd = command.TrySetupAsyncCommand(cnn, paramReader);
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
                 result = await cmd.ExecuteScalarAsync(command.CancellationToken).ConfigureAwait(false);
                 command.OnCompleted();
             }

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -393,8 +393,7 @@ namespace Dapper
         /// </summary>
         private static DbCommand TrySetupAsyncCommand(this CommandDefinition command, IDbConnection cnn, Action<IDbCommand, object> paramReader)
         {
-            var result = command.SetupCommand(cnn, paramReader);
-            if (result is DbCommand dbCommand)
+            if (command.SetupCommand(cnn, paramReader) is DbCommand dbCommand)
             {
                 return dbCommand;
             }

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -384,7 +384,7 @@ namespace Dapper
             }
             else
             {
-                throw new InvalidOperationException("Async operations require use of a DbConnection");
+                throw new InvalidOperationException("Async operations require use of a DbConnection or an already-open IDbConnection");
             }
         }
 
@@ -393,13 +393,14 @@ namespace Dapper
         /// </summary>
         private static DbCommand TrySetupAsyncCommand(this CommandDefinition command, IDbConnection cnn, Action<IDbCommand, object> paramReader)
         {
-            if (cnn is DbConnection)
+            var result = command.SetupCommand(cnn, paramReader);
+            if (result is DbCommand dbCommand)
             {
-                return (DbCommand)command.SetupCommand(cnn, paramReader);
+                return dbCommand;
             }
             else
             {
-                throw new InvalidOperationException("Async operations require use of a DbConnection");
+                throw new InvalidOperationException("Async operations require use of a DbConnection or an IDbConnection where .CreateCommand() returns a DbCommand");
             }
         }
 


### PR DESCRIPTION
Perhaps in v2 we move these to DbConnection itself ratherr than IDbConnection for the extensions to eliminate the case, but that's breaking...for now we can at least throw a better error. See #757 for details.

@mgravell note: I'm now passing a cancellation token (effectively unused...but fixes when we normalize them all in v2) in `MultiMapAsync` (line 963 below). I assume this was just an oversight initially but if there's a reason let me know and I can back that out & add a comment on why.