### PR TITLE
Optimization of Query* methods via [MultiMapImpl] method

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1441,7 +1441,12 @@ namespace Dapper
                 {
                     while (reader.Read())
                     {
-                        yield return mapIt(reader);
+                        var mapedResult = mapIt(reader);
+
+                        if (mapedResult == null)
+                            continue;
+
+                        yield return mapedResult;
                     }
                     if (finalize)
                     {


### PR DESCRIPTION
In the [Muti-Mapping cases](http://dapper-tutorial.net/result-multi-mapping) some double work is done.
First duplicates are put on the list, then they are removed. Why not just ignore them? 
Moreover, using the `Distinct()` method doesn't seem to be a good choice when we have to work with a large number of rows.

Also when using a wrapper like this

```
public static Task<IEnumerable<TFirst>> QueryJoinAsync<TFirst, TSecond, TID>(this IDbConnection connection, string sql, Func<TFirst, TID> getId, Action<TFirst, TSecond> addSecond, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
{
    var itemsDict = new Dictionary<TID, TFirst>();

    var items= connection.QueryAsync<TFirst, TSecond, TFirst>(
            sql,
            (first, second) =>
            {
                TID firstId = getId(first);
                bool exist = itemsDict.TryGetValue(firstId, out TFirst firstEntry);

                if (!exist)
                {
                    firstEntry = first;
                    itemsDict.Add(firstId, firstEntry);
                }

                addSecond(firstEntry, second);
                return firstEntry;
            },
            param, transaction, buffered, splitOn, commandTimeout, commandType
            );

    return items;
}
```

I can't use `Distinct()` within the wrapper because I just want to return `Task<..>` immediately without using state machine (`async/await`) twice and I have to keep in mind to do it each time after `QueryJoinAsync`.

With this pull-request changes, it would be possible to return just nulls instead of duplicate values in the mapper-delegate like in this version of wrapper:

```
public static Task<IEnumerable<TFirst>> QueryJoinAsync<TFirst, TSecond, TID>(this IDbConnection connection, string sql, Func<TFirst, TID> getId, Action<TFirst, TSecond> addSecond, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
    where TFirst : class
{
    var itemsDict = new Dictionary<TID, TFirst>();

    var items = connection.QueryAsync<TFirst, TSecond, TFirst>(
            sql,
            (first, second) =>
            {
                TID firstId = getId(first);
                bool exist = itemsDict.TryGetValue(firstId, out TFirst firstEntry);

                if (!exist)
                {
                    firstEntry = first;
                    itemsDict.Add(firstId, firstEntry);
                }

                addSecond(firstEntry, second);

                if (exist)
                    return null;

                return firstEntry;
            },
            param, transaction, buffered, splitOn, commandTimeout, commandType
            );

    return items;
}
```
without any additional work on finding and removing them.