### PR TITLE
Discarding duplicate fields when mapping

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -3097,7 +3097,7 @@ namespace Dapper
                 throw MultiMapException(reader);
             }
 
-            var names = Enumerable.Range(startBound, length).Select(i => reader.GetName(i)).ToArray();
+            var names = Enumerable.Range(startBound, length).Select(i => reader.GetName(i)).Distinct().ToArray();
 
             ITypeMap typeMap = GetTypeMap(type);
 


### PR DESCRIPTION
The issue description is here:
https://stackoverflow.com/questions/49601732/dapper-query-incorrectly-maps-the-entity-id

It fixed the issue but I haven't delved deeply into that code, so I cannot be absolutely sure that it will not lead to any bugs.

I think it's better to fix it anyway, because sometimes unintentionally anyone can just forget to limit the `SELECT` and get a false result without even knowing about it. And it will be great if it is prevented by default. Also, it reduces the number of mappings of unnecessary fields.