### PR TITLE
Change Insert<T>(...) return type from [long] to [int]

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -321,7 +321,7 @@ namespace Dapper.Contrib.Extensions
         /// <param name="transaction">The transaction to run under, null (the default) if none</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout</param>
         /// <returns>Identity of inserted entity, or number of inserted rows if inserting a list</returns>
-        public static long Insert<T>(this IDbConnection connection, T entityToInsert, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
+        public static int Insert<T>(this IDbConnection connection, T entityToInsert, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             var isList = false;
 


### PR DESCRIPTION
Couldn't find any reason why the return type of [Insert<T>(...)](https://github.com/StackExchange/Dapper/blob/master/Dapper.Contrib/SqlMapperExtensions.cs#L324) method is `long`, while the values obtained from the internal [adapter.Insert(...)](https://github.com/StackExchange/Dapper/blob/master/Dapper.Contrib/SqlMapperExtensions.cs#L381) & [connection.Execute(...)](https://github.com/StackExchange/Dapper/blob/master/Dapper.Contrib/SqlMapperExtensions.cs#L388) calls are of type `int`. 
The return type of the similar synchronous  [InsertAsync<T>(...)](https://github.com/StackExchange/Dapper/blob/master/Dapper.Contrib/SqlMapperExtensions.Async.cs#L139) method is `int` too.