### PR TITLE
DbGeometry and DbGeography SRIDs

### DIFF
--- a/Dapper.EntityFramework/DbGeographyHandler.cs
+++ b/Dapper.EntityFramework/DbGeographyHandler.cs
@@ -51,7 +51,7 @@ namespace Dapper.EntityFramework
             if (value == null || value is DBNull) return null;
             if (value is SqlGeography geo)
             {
-                return DbGeography.FromBinary(geo.STAsBinary().Value);
+                return DbGeography.FromBinary(geo.STAsBinary().Value, geo.STSrid.Value);
             }
             return DbGeography.FromText(value.ToString());
         }

--- a/Dapper.EntityFramework/DbGeometryHandler.cs
+++ b/Dapper.EntityFramework/DbGeometryHandler.cs
@@ -51,7 +51,7 @@ namespace Dapper.EntityFramework
             if (value == null || value is DBNull) return null;
             if (value is SqlGeometry geo)
             {
-                return DbGeometry.FromBinary(geo.STAsBinary().Value);
+                return DbGeometry.FromBinary(geo.STAsBinary().Value, geo.STSrid.Value);
             }
             return DbGeometry.FromText(value.ToString());
         }


### PR DESCRIPTION
When reading Geometry and Geography spatial values from the database, we need to specify the SRID explicitly to retain it in the DbGeometry / DbGeography type.  I found this problem some time ago on a work project, and managed to fix it locally in that installation (I seem to recall working from the DbGeometryHandler code posted by @mgravell in Stack Overflow post).

Anyway; I believe I have provided an appropriate pair of new tests, that fail for me when running via xUnit Test Runner in VIsual Studio, and are fixed by my code changes.
My suggested fix is the minor mod in each of the two Db_Xxxxxxx_Handler.cs files.

There is an unrelated fix to the location of Redmond (the addition of a minus sign).

Unfortunately I have not figured out the whole build process, so when I try to run the wider unit tests via TestRunner or the build powershell script I can not complete a full build. Any pointers to documentation on how to set up the build environment for Dapper, with the various database tests would be appreciated.

Nij
(First time OS contribution)
