### PR TITLE
Tweaks to Contrib SqlMapperExtensions

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -391,7 +391,7 @@ namespace Dapper.Contrib.Extensions
             else
             {
                 //insert list of entities
-                var cmd = $"insert into [{name}] ({sbColumnList}) values ({sbParameterList})";
+                var cmd = $"insert into {name} ({sbColumnList}) values ({sbParameterList})";
                 returnVal = connection.Execute(cmd, entityToInsert, transaction, commandTimeout);
             }
             if (wasClosed) connection.Close();
@@ -538,7 +538,7 @@ namespace Dapper.Contrib.Extensions
         {
             var type = typeof(T);
             var name = GetTableName(type);
-            var statement = $"delete from [{name}]";
+            var statement = $"delete from {name}";
             var deleted = connection.Execute(statement, null, transaction, commandTimeout);
             return deleted > 0;
         }

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -181,7 +181,7 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(Get));
                 var name = GetTableName(type);
 
-                sql = $"select * from {name} where {key.Name} = @id";
+                sql = $"select * from [{name}] where {key.Name} = @id";
                 GetQueries[type.TypeHandle] = sql;
             }
 
@@ -384,7 +384,7 @@ namespace Dapper.Contrib.Extensions
             else
             {
                 //insert list of entities
-                var cmd = $"insert into {name} ({sbColumnList}) values ({sbParameterList})";
+                var cmd = $"insert into [{name}] ({sbColumnList}) values ({sbParameterList})";
                 returnVal = connection.Execute(cmd, entityToInsert, transaction, commandTimeout);
             }
             if (wasClosed) connection.Close();
@@ -531,7 +531,7 @@ namespace Dapper.Contrib.Extensions
         {
             var type = typeof(T);
             var name = GetTableName(type);
-            var statement = $"delete from {name}";
+            var statement = $"delete from [{name}]";
             var deleted = connection.Execute(statement, null, transaction, commandTimeout);
             return deleted > 0;
         }

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -26,10 +26,12 @@ namespace Dapper.Tests.Contrib
     public class SqlServerTestSuite : TestSuite
     {
         private const string DbName = "tempdb";
+        private const string Server = @".\SQLEXPRESS";
+
         public static string ConnectionString =>
             IsAppVeyor
                 ? @"Server=(local)\SQL2016;Database=tempdb;User ID=sa;Password=Password12!"
-                : $"Data Source=.;Initial Catalog={DbName};Integrated Security=True";
+                : $@"Data Source={Server};Initial Catalog={DbName};Integrated Security=True";
         public override IDbConnection GetConnection() => new SqlConnection(ConnectionString);
 
         static SqlServerTestSuite()

--- a/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
+++ b/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
@@ -5,7 +5,7 @@
     <Description>Dapper Core Performance Suite</Description>
     <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net471</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dapper\Dapper.csproj" />

--- a/Dapper.Tests/Dapper.Tests.csproj
+++ b/Dapper.Tests/Dapper.Tests.csproj
@@ -20,11 +20,10 @@
     <ProjectReference Include="..\Dapper\Dapper.csproj" />
     <ProjectReference Include="..\Dapper.Contrib\Dapper.Contrib.csproj" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.9.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MySql.Data" Version="8.0.8-dmr" />
-    <PackageReference Include="Npgsql" Version="3.2.5" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />    
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />
@@ -46,10 +45,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.1" />
+    <PackageReference Include="Npgsql" Version="3.2.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.0" />
+    <PackageReference Include="Npgsql" Version="4.0.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated package dependencies (in tests). Shifted some into .NETCoreApp 1.0 and .NETCoreApp 2.0 conditionals.

Breaking Change: GetTableName returns the name surrounded by Square Brackets, so no need to wrap keyword table names manually (through TableNameMapper or Attribute). Unsure if all supported DBs support this notation, but there was an added [] in the Insert<T> method, which would have broken supported DBs if that was the case.

Updated the tests to not wrap table names where they were. All SQL Server tests pass.

Breaking Change: Changed ordering of GetTableName conditions. I feel that because an attribute is closer to an object, it should be used over other mechanisms (e.g. TableNameMapper). So now conditions evaluate:

1. TableAttribute
2. TableNameMapper
3. TypeName with an 's' (there's actually a good pluralizer somewhere, but perhaps that is better to include as a dependency if the developer uses TableNameMapper).