### PR TITLE
build.ps1 is not handling pre-release build number correctly.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ function CalculateVersion() {
         Exit 1
     }
 
-    if ($semVersion -contains "-") {
+    if ($semVersion -match "-") {
         return "$semVersion-$BuildNumber" #prerelease
     } else {
         return "$semVersion" #release


### PR DESCRIPTION
The -Contains operator doesn't do substring comparisons.

> -Contains
>Description: Containment operator. Tells whether a collection of reference values includes a single test value.

Should be using -Match operator instead.