### PR TITLE
DeleteAsync - use adapter to format column name equals statement.

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -312,10 +312,12 @@ namespace Dapper.Contrib.Extensions
             var sb = new StringBuilder();
             sb.AppendFormat("DELETE FROM {0} WHERE ", name);
 
+            var adapter = GetFormatter(connection);
+            
             for (var i = 0; i < keyProperties.Count; i++)
             {
                 var property = keyProperties[i];
-                sb.AppendFormat("{0} = @{1}", property.Name, property.Name);
+                adapter.AppendColumnNameEqualsValue(sb, property.Name);
                 if (i < keyProperties.Count - 1)
                     sb.Append(" AND ");
             }


### PR DESCRIPTION
Use adapter to format column name equals, bringing it in line with `Delete` behaviour.