### PR TITLE
Sql columnNames to class property ColumnAttributes

### DIFF
--- a/Dapper.StrongName.csproj
+++ b/Dapper.StrongName.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Dapper.StrongName</AssemblyName>
+    <PackageTags>orm;sql;micro-orm</PackageTags>
+    <Title>Dapper (Strong Named)</Title>
+    <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
+    <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
+    <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Dapper\**\*.cs" Exclude="..\Dapper\obj\**\*.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -32,4 +32,7 @@
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+  </ItemGroup>
 </Project>

--- a/Dapper.csproj
+++ b/Dapper.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>Dapper</PackageId>
+    <PackageTags>orm;sql;micro-orm</PackageTags>
+    <Title>Dapper</Title>
+    <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
+    <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
+    <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -26,5 +26,8 @@
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+  </ItemGroup>  
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/Dapper/DefaultTypeMap.cs
+++ b/Dapper/DefaultTypeMap.cs
@@ -153,7 +153,10 @@ namespace Dapper
         public SqlMapper.IMemberMap GetMember(string columnName)
         {
             var property = Properties.Find(p => string.Equals(p.Name, columnName, StringComparison.Ordinal))
-               ?? Properties.Find(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase));
+               ?? Properties.Find(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase))
+               ?? Properties.Find(p =>
+                    string.Equals(((ColumnAttribute)p.GetCustomAttribute(typeof(ColumnAttribute)))?.Name,
+                        columnName, StringComparison.OrdinalIgnoreCase));
 
             if (property == null && MatchNamesWithUnderscores)
             {

--- a/DefaultTypeMap.cs
+++ b/DefaultTypeMap.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Reflection;
+
+namespace Dapper
+{
+    /// <summary>
+    /// Represents default type mapping strategy used by Dapper
+    /// </summary>
+    public sealed class DefaultTypeMap : SqlMapper.ITypeMap
+    {
+        private readonly List<FieldInfo> _fields;
+        private readonly Type _type;
+
+        /// <summary>
+        /// Creates default type map
+        /// </summary>
+        /// <param name="type">Entity type</param>
+        public DefaultTypeMap(Type type)
+        {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+
+            _fields = GetSettableFields(type);
+            Properties = GetSettableProps(type);
+            _type = type;
+        }
+#if NETSTANDARD1_3
+        private static bool IsParameterMatch(ParameterInfo[] x, ParameterInfo[] y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x == null || y == null) return false;
+            if (x.Length != y.Length) return false;
+            for (int i = 0; i < x.Length; i++)
+                if (x[i].ParameterType != y[i].ParameterType) return false;
+            return true;
+        }
+#endif
+        internal static MethodInfo GetPropertySetter(PropertyInfo propertyInfo, Type type)
+        {
+            if (propertyInfo.DeclaringType == type) return propertyInfo.GetSetMethod(true);
+#if NETSTANDARD1_3
+            return propertyInfo.DeclaringType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    .Single(x => x.Name == propertyInfo.Name
+                        && x.PropertyType == propertyInfo.PropertyType
+                        && IsParameterMatch(x.GetIndexParameters(), propertyInfo.GetIndexParameters())
+                        ).GetSetMethod(true);
+#else
+            return propertyInfo.DeclaringType.GetProperty(
+                   propertyInfo.Name,
+                   BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                   Type.DefaultBinder,
+                   propertyInfo.PropertyType,
+                   propertyInfo.GetIndexParameters().Select(p => p.ParameterType).ToArray(),
+                   null).GetSetMethod(true);
+#endif
+        }
+
+        internal static List<PropertyInfo> GetSettableProps(Type t)
+        {
+            return t
+                  .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                  .Where(p => GetPropertySetter(p, t) != null)
+                  .ToList();
+        }
+
+        internal static List<FieldInfo> GetSettableFields(Type t)
+        {
+            return t.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).ToList();
+        }
+
+        /// <summary>
+        /// Finds best constructor
+        /// </summary>
+        /// <param name="names">DataReader column names</param>
+        /// <param name="types">DataReader column types</param>
+        /// <returns>Matching constructor or default one</returns>
+        public ConstructorInfo FindConstructor(string[] names, Type[] types)
+        {
+            var constructors = _type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            foreach (ConstructorInfo ctor in constructors.OrderBy(c => c.IsPublic ? 0 : (c.IsPrivate ? 2 : 1)).ThenBy(c => c.GetParameters().Length))
+            {
+                ParameterInfo[] ctorParameters = ctor.GetParameters();
+                if (ctorParameters.Length == 0)
+                    return ctor;
+
+                if (ctorParameters.Length != types.Length)
+                    continue;
+
+                int i = 0;
+                for (; i < ctorParameters.Length; i++)
+                {
+                    if (!string.Equals(ctorParameters[i].Name, names[i], StringComparison.OrdinalIgnoreCase))
+                        break;
+                    if (types[i] == typeof(byte[]) && ctorParameters[i].ParameterType.FullName == SqlMapper.LinqBinary)
+                        continue;
+                    var unboxedType = Nullable.GetUnderlyingType(ctorParameters[i].ParameterType) ?? ctorParameters[i].ParameterType;
+                    if ((unboxedType != types[i] && !SqlMapper.HasTypeHandler(unboxedType))
+                        && !(unboxedType.IsEnum() && Enum.GetUnderlyingType(unboxedType) == types[i])
+                        && !(unboxedType == typeof(char) && types[i] == typeof(string))
+                        && !(unboxedType.IsEnum() && types[i] == typeof(string)))
+                    {
+                        break;
+                    }
+                }
+
+                if (i == ctorParameters.Length)
+                    return ctor;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the constructor, if any, that has the ExplicitConstructorAttribute on it.
+        /// </summary>
+        public ConstructorInfo FindExplicitConstructor()
+        {
+            var constructors = _type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+#if NETSTANDARD1_3
+            var withAttr = constructors.Where(c => c.CustomAttributes.Any(x => x.AttributeType == typeof(ExplicitConstructorAttribute))).ToList();
+#else
+            var withAttr = constructors.Where(c => c.GetCustomAttributes(typeof(ExplicitConstructorAttribute), true).Length > 0).ToList();
+#endif
+
+            if (withAttr.Count == 1)
+            {
+                return withAttr[0];
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets mapping for constructor parameter
+        /// </summary>
+        /// <param name="constructor">Constructor to resolve</param>
+        /// <param name="columnName">DataReader column name</param>
+        /// <returns>Mapping implementation</returns>
+        public SqlMapper.IMemberMap GetConstructorParameter(ConstructorInfo constructor, string columnName)
+        {
+            var parameters = constructor.GetParameters();
+
+            return new SimpleMemberMap(columnName, parameters.FirstOrDefault(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        /// <summary>
+        /// Gets member mapping for column
+        /// </summary>
+        /// <param name="columnName">DataReader column name</param>
+        /// <returns>Mapping implementation</returns>
+        public SqlMapper.IMemberMap GetMember(string columnName)
+        {
+            var property = Properties.Find(p => string.Equals(p.Name, columnName, StringComparison.Ordinal))
+                ?? Properties.Find(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase))
+                ?? Properties.Find(p =>
+                    string.Equals(((ColumnAttribute)p.GetCustomAttribute(typeof(ColumnAttribute)))?.Name,
+                        columnName, StringComparison.OrdinalIgnoreCase));
+
+            if (property == null && MatchNamesWithUnderscores)
+            {
+                property = Properties.Find(p => string.Equals(p.Name, columnName.Replace("_", ""), StringComparison.Ordinal))
+                    ?? Properties.Find(p => string.Equals(p.Name, columnName.Replace("_", ""), StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (property != null)
+                return new SimpleMemberMap(columnName, property);
+
+            // roslyn automatically implemented properties, in particular for get-only properties: <{Name}>k__BackingField;
+            var backingFieldName = "<" + columnName + ">k__BackingField";
+
+            // preference order is:
+            // exact match over underscre match, exact case over wrong case, backing fields over regular fields, match-inc-underscores over match-exc-underscores
+            var field = _fields.Find(p => string.Equals(p.Name, columnName, StringComparison.Ordinal))
+                ?? _fields.Find(p => string.Equals(p.Name, backingFieldName, StringComparison.Ordinal))
+                ?? _fields.Find(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase))
+                ?? _fields.Find(p => string.Equals(p.Name, backingFieldName, StringComparison.OrdinalIgnoreCase));
+
+            if (field == null && MatchNamesWithUnderscores)
+            {
+                var effectiveColumnName = columnName.Replace("_", "");
+                backingFieldName = "<" + effectiveColumnName + ">k__BackingField";
+
+                field = _fields.Find(p => string.Equals(p.Name, effectiveColumnName, StringComparison.Ordinal))
+                    ?? _fields.Find(p => string.Equals(p.Name, backingFieldName, StringComparison.Ordinal))
+                    ?? _fields.Find(p => string.Equals(p.Name, effectiveColumnName, StringComparison.OrdinalIgnoreCase))
+                    ?? _fields.Find(p => string.Equals(p.Name, backingFieldName, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (field != null)
+                return new SimpleMemberMap(columnName, field);
+
+            return null;
+        }
+        /// <summary>
+        /// Should column names like User_Id be allowed to match properties/fields like UserId ?
+        /// </summary>
+        public static bool MatchNamesWithUnderscores { get; set; }
+
+        /// <summary>
+        /// The settable properties for this typemap
+        /// </summary>
+        public List<PropertyInfo> Properties { get; }
+    }
+}


### PR DESCRIPTION
Added the ability to map Sql column names to class property ColumnAttributes. This works by adding the ColumnAttribute to the class property, setting its name the same as the column name in the database.
Example - this will map the database column named "person_id" to the class property named "ContactPersonId":
    [Column("person_id")]
    public int ContactPersonId { get; set; }
This requires references to System.ComponentModel.Annotations - Version="4.5.0" and System.ComponentModel.DataAnnotations.