### PR TITLE
Handling classes with Guid type properties and persisting them to a sqlite database.

### DIFF
--- a/Dapper.Tests.SQlite/ClassWithGuidPropertyWithDefaultConstructor.cs
+++ b/Dapper.Tests.SQlite/ClassWithGuidPropertyWithDefaultConstructor.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace Dapper.Tests.SQlite
+{
+    /// <summary>
+    /// ClassWithGuidPropertyWithDefaultConstructor: simple class with a Guid property and a default constructor.
+    /// </summary>
+    public class ClassWithGuidPropertyWithDefaultConstructor : IEquatable<ClassWithGuidPropertyWithDefaultConstructor>
+    {
+        /// <summary>
+        /// Id: is the GUID id for "this" record.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Name: is an arbitary (null-guid) dummy property
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <inheritdoc cref="ClassWithGuidPropertyWithDefaultConstructor " />
+        public bool Equals(ClassWithGuidPropertyWithDefaultConstructor x, ClassWithGuidPropertyWithDefaultConstructor y)
+        {
+            return x.Id.Equals(y.Id) && x.Name.Equals(y.Name);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(ClassWithGuidPropertyWithDefaultConstructor other)
+        {
+            return Id.Equals(other.Id) && Name.Equals(other.Name);
+        }
+
+        /// <inheritdoc cref="ClassWithGuidPropertyWithDefaultConstructor" />
+        public int GetHashCode(ClassWithGuidPropertyWithDefaultConstructor obj) => throw new NotImplementedException();
+    }
+
+}

--- a/Dapper.Tests.SQlite/ClassWithGuidPropertyWithNoDefaultConstructor.cs
+++ b/Dapper.Tests.SQlite/ClassWithGuidPropertyWithNoDefaultConstructor.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+namespace Dapper.Tests.SQlite
+{
+    /// <summary>
+    /// ClassWithGuidPropertyWithNoDefaultConstructor: simple class with a Guid property and no default constructor.
+    /// </summary>
+    public class ClassWithGuidPropertyWithNoDefaultConstructor : IEquatable<ClassWithGuidPropertyWithNoDefaultConstructor>
+    {
+        /// <summary>
+        /// Id: is the GUID id for "this" record.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Name: is an arbitary (null-guid) dummy property
+        /// </summary>
+        public string Name { get; set; }
+
+        public ClassWithGuidPropertyWithNoDefaultConstructor(Guid id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        /// <inheritdoc cref="ClassWithGuidPropertyWithNoDefaultConstructor" />
+        public bool Equals(ClassWithGuidPropertyWithNoDefaultConstructor x, ClassWithGuidPropertyWithNoDefaultConstructor y)
+        {
+            return x.Id.Equals(y.Id) && x.Name.Equals(y.Name);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(ClassWithGuidPropertyWithNoDefaultConstructor other)
+        {
+            return Id.Equals(other.Id) && Name.Equals(other.Name);
+        }
+
+        /// <inheritdoc cref="ClassWithGuidPropertyWithNoDefaultConstructor" />
+        public int GetHashCode(ClassWithGuidPropertyWithNoDefaultConstructor obj) => throw new NotImplementedException();
+    }
+
+}

--- a/Dapper.Tests.SQlite/Dapper.Tests.SQlite.csproj
+++ b/Dapper.Tests.SQlite/Dapper.Tests.SQlite.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+  
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.1.0" />
+  </ItemGroup>
+  
+    <ItemGroup>
+      <ProjectReference Include="..\Dapper\Dapper.csproj" />
+    </ItemGroup>
+
+
+</Project>

--- a/Dapper.Tests.SQlite/GuidHandler.cs
+++ b/Dapper.Tests.SQlite/GuidHandler.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+
+namespace Dapper.Tests.SQlite
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class GuidHandler : SqlMapper.TypeHandler<Guid>
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public override Guid Parse(object value)
+        {
+            return new Guid((byte[])value);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="parameter"></param>
+        /// <param name="value"></param>
+        public override void SetValue(IDbDataParameter parameter, Guid value)
+        {
+            parameter.Value = value.ToByteArray();
+        }
+    }
+}

--- a/Dapper.Tests.SQlite/TestGuidPropertyIssue.cs
+++ b/Dapper.Tests.SQlite/TestGuidPropertyIssue.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Dapper.Tests.SQlite
+{
+
+    /// <summary>
+    ///  Test the handling of classes with guid type properties and persisting them to a sqlite database.
+    /// </summary>
+    public class TestGuidPropertyIssue
+    {
+        private const string TEST_STRING = "Test Name";
+        private const string CREATE_STATEMENT = @"CREATE TABLE IF NOT EXISTS SomeTable (Id UNIQUEIDENTIFIER, Name NVARCHAR(255))";
+        private const string INSERT_STATEMENT = @"INSERT INTO SomeTable (Id, Name) VALUES(@Id, @Name)";
+        private const string SELECT_STATEMENT = @"SELECT * FROM SomeTable";
+
+        private static SqliteConnection GetSQLiteConnection(bool open = true)
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            if (open) connection.Open();
+            return connection;
+        }
+
+        public TestGuidPropertyIssue()
+        {
+            // Add the new Guid handler for all the tests.
+            SqlMapper.AddTypeHandler(new GuidHandler());
+        }
+
+        [Fact]
+        public void Test_select_of_class_with_guid_property_and_default_constructor()
+        {
+            using (var connection = GetSQLiteConnection())
+            {
+                // Arrange.
+                var seed = Guid.NewGuid();
+
+                var expectedRes = new ClassWithGuidPropertyWithDefaultConstructor()
+                {
+                    Id = seed,
+                    Name = TEST_STRING
+                };
+
+                connection.Execute(CREATE_STATEMENT);
+                connection.Execute(INSERT_STATEMENT, expectedRes);
+
+                // Act.
+                var res = connection.Query<ClassWithGuidPropertyWithDefaultConstructor>(SELECT_STATEMENT).FirstOrDefault();
+
+                // Assert.
+                Assert.Equal(expectedRes, res);
+            }
+        }
+
+        [Fact]
+        public void Test_select_of_class_with_guid_property_and_no_default_constructor()
+        {
+            using (var connection = GetSQLiteConnection())
+            {
+                // Arrange.
+                var seed = Guid.NewGuid();
+
+                var expectedRes = new ClassWithGuidPropertyWithNoDefaultConstructor( seed, TEST_STRING);
+
+                connection.Execute(CREATE_STATEMENT);
+                connection.Execute(INSERT_STATEMENT, expectedRes);
+
+                // Act.
+                var res = connection.Query<ClassWithGuidPropertyWithNoDefaultConstructor>(SELECT_STATEMENT).FirstOrDefault();
+
+                // Assert.
+                Assert.Equal(expectedRes, res);
+            }
+        }
+
+        [Fact]
+        public void Test_Insert_Using_Anonymous_Object()
+        {
+            using (var connection = GetSQLiteConnection())
+            {
+                // Arrange.
+                var seed = Guid.NewGuid();
+
+                var expectedRes = new ClassWithGuidPropertyWithNoDefaultConstructor(seed, TEST_STRING);
+
+                connection.Execute(CREATE_STATEMENT);
+                connection.Execute(INSERT_STATEMENT, new
+                {
+                    Id = seed,
+                    Name = "Test Name"
+                });
+
+                // Act.
+                var res = connection.Query<ClassWithGuidPropertyWithNoDefaultConstructor>(SELECT_STATEMENT).FirstOrDefault();
+
+                // Assert.
+                Assert.Equal(expectedRes, res);
+            }
+        }
+
+    }
+}

--- a/Dapper.sln
+++ b/Dapper.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.EntityFramework.Stro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Tests.Performance", "Dapper.Tests.Performance\Dapper.Tests.Performance.csproj", "{F017075A-2969-4A8E-8971-26F154EB420F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Tests.SQlite", "Dapper.Tests.SQlite\Dapper.Tests.SQlite.csproj", "{AEFAC4E2-5B64-42FA-B9DA-6FDBE9C6066E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -88,6 +90,10 @@ Global
 		{F017075A-2969-4A8E-8971-26F154EB420F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F017075A-2969-4A8E-8971-26F154EB420F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F017075A-2969-4A8E-8971-26F154EB420F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEFAC4E2-5B64-42FA-B9DA-6FDBE9C6066E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEFAC4E2-5B64-42FA-B9DA-6FDBE9C6066E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEFAC4E2-5B64-42FA-B9DA-6FDBE9C6066E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEFAC4E2-5B64-42FA-B9DA-6FDBE9C6066E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -103,6 +109,7 @@ Global
 		{8A74F0B6-188F-45D2-8A4B-51E4F211805A} = {4E956F6B-6BD8-46F5-BC85-49292FF8F9AB}
 		{39D3EEB6-9C05-4F4A-8C01-7B209742A7EB} = {4E956F6B-6BD8-46F5-BC85-49292FF8F9AB}
 		{F017075A-2969-4A8E-8971-26F154EB420F} = {568BD46C-1C65-4D44-870C-12CD72563262}
+		{AEFAC4E2-5B64-42FA-B9DA-6FDBE9C6066E} = {568BD46C-1C65-4D44-870C-12CD72563262}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {928A4226-96F3-409A-8A83-9E7444488710}

--- a/Dapper/GuidHandler.cs
+++ b/Dapper/GuidHandler.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Text;
 
-namespace Dapper.Tests.SQlite
+namespace Dapper
 {
     /// <summary>
     /// 


### PR DESCRIPTION
This simple Guid handler should fix issue #447 (and duplicate issue: #718). It implements the method suggested by numerous other users but leaves the byte order (endian) to the .net layer.
It also fixes the guid equivalent issue raised in #461.

Note: this fix has only been tested against .net core 2.1.