### PR TITLE
Make `SqlBuilder.AddClause()` method `public`

### DIFF
--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -102,7 +102,7 @@ namespace Dapper
         public Template AddTemplate(string sql, dynamic parameters = null) =>
             new Template(this, sql, parameters);
 
-        protected SqlBuilder AddClause(string name, string sql, object parameters, string joiner, string prefix = "", string postfix = "", bool isInclusive = false)
+        public SqlBuilder AddClause(string name, string sql, object parameters, string joiner, string prefix = "", string postfix = "", bool isInclusive = false)
         {
             if (!_data.TryGetValue(name, out Clauses clauses))
             {


### PR DESCRIPTION
In order to extend `SqlBuilder` with additional methods such as `InsertInto()` or `Update()`, one currently would have to derive from `SqlBuilder` and create a less obvious `SqlBuilderEx` type of class for use in a project.

A simpler approach would instead be to create only an extension method that calls `AddClause()`.  This requires that the `AddClause()` method be made public.

This update appears to be super low-risk with the super upside of inviting creative solutions based on `SqlBuilder` to flourish in the wild and eventually make their way back into this shared library.