### PR TITLE
Fix Issue #1080

### DIFF
--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -325,9 +325,18 @@ namespace Dapper
                 }
             }
 
-            var builder = new StringBuilder("select 1 from INFORMATION_SCHEMA.TABLES where ");
-            if (!string.IsNullOrEmpty(schemaName)) builder.Append("TABLE_SCHEMA = @schemaName AND ");
-            builder.Append("TABLE_NAME = @name");
+            bool isSqliteConnection = _connection.GetType().Name.ToLower().Equals("sqliteconnection");
+            var builder = new StringBuilder("select 1 from ");
+            if (isSqliteConnection)
+            {
+                builder.Append("SQLITE_MASTER where NAME = @name");
+            }
+            else
+            {
+                builder.Append("INFORMATION_SCHEMA.TABLES where ");
+                if (!string.IsNullOrEmpty(schemaName)) builder.Append("TABLE_SCHEMA = @schemaName AND ");
+                builder.Append("TABLE_NAME = @name");
+            }
 
             return _connection.Query(builder.ToString(), new { schemaName, name }, _transaction).Count() == 1;
         }


### PR DESCRIPTION
Sqlite doesn't have a table called INFORMATION_SCHEMA.TABLES, instead you must use SQLITE_MASTER table.   Updated the code to determine if it IsSqliteConection and append the correct table name.   Also SQLITE_MASTER does not have a column name called "TABLE_NAME".