### PR TITLE
More detailed error message on unsupported literal type

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2323,7 +2323,7 @@ namespace Dapper
                                 return sb.Append(')').__ToStringRecycle();
                             }
                         }
-                        throw new NotSupportedException(value.GetType().Name);
+                        throw new NotSupportedException($"The type '{value.GetType().Name}' is not supported for SQL literals.");
                 }
             }
         }


### PR DESCRIPTION
instead of exception message of `DateTime`, you'll get `The type 'DateTime' is not supported for SQL literals.`, which is much more helpful when trying to figure out what went wrong