### PR TITLE
Force static constructor calls for DefaultTypeMap _fields types

### DIFF
--- a/Dapper/DefaultTypeMap.cs
+++ b/Dapper/DefaultTypeMap.cs
@@ -23,6 +23,12 @@ namespace Dapper
                 throw new ArgumentNullException(nameof(type));
 
             _fields = GetSettableFields(type);
+			
+			// when using reflection, there's no guarantee that static constructors are called
+			// before object instantiation, so do it manually for all types (whose constructors haven't been called)
+			foreach(var field in _fields)
+                System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(field.FieldType.TypeHandle);
+			
             Properties = GetSettableProps(type);
             _type = type;
         }


### PR DESCRIPTION
Static constructors are not guaranteed to be called when instantiated using Reflection. I encountered this bug when attempting to register TypeHandlers in the static constructor of a generic function, and then having DataExceptions thrown by Dapper when attempting to query a database for objects containing fields of the generic type.

The following code example demonstrates the issue: https://gist.github.com/MathiasPius/cd6e7d3b10aca8d0212e8b9b3435d852#file-program-cs

When run, it produces the following exception: 
```
InvalidCastException: Unable to cast object of type 'System.Guid' to type 'ID`1[DapperStaticConstructorBug.Program+ComplexObject]'.
```
Because the static constructor of `ID<ComplexObject>` is never called, and the TypeHandler for `ID<ComplexObject>` is never added.

This pull request modifies only the `DefaultTypeMap` and makes it explicitly call the static constructor of any _field types, if they exist. The `RunClassConstructor` function also guarantees that the static constructor is only ever called once, and will not re-run static constructors, if they have already been run.

Not too familiar with the Dapper codebase, so let me know if there's a better way to go about this.