### PR TITLE
Support splitting using the type name as a prefix alias

### DIFF
--- a/Dapper.Tests/MultiMapTests.cs
+++ b/Dapper.Tests/MultiMapTests.cs
@@ -597,7 +597,7 @@ Order by p.Id
                      cast('01 Feb 2013' as datetime) as CreateDate,
                      'ghi' as Name, 'def' as Phone",
             (T, P) => { T.Author = P; return T; },
-            null, null, true, "ID,Name").Single();
+            null, null, true, "ID,ID").Single();
 
             Assert.Equal(123, result.ID);
             Assert.Equal("abc", result.Title);
@@ -611,6 +611,29 @@ Order by p.Id
             Assert.Null(result.Author.Address);
         }
 
+        [Fact]
+        public void TestSplitWithTypeAliasColumns()
+        {
+            var result = connection.Query<Topic, Profile, Topic>(
+            @"select 123 as ID, 'abc' as Title,
+                     cast('01 Feb 2013' as datetime) as CreateDate,
+                     'def' as Name, 'geh' as Content, 789 as ProfileId, 
+                    'gaa' as ProfilePhone, 'ghi' as ProfileName",
+            (T, P) => { T.Author = P; return T; },
+            null, null, true, "ID").Single();
+
+            Assert.Equal(123, result.ID);
+            Assert.Equal("abc", result.Title);
+            Assert.Equal(new DateTime(2013, 2, 1), result.CreateDate);
+            Assert.Equal("def", result.Name);
+            Assert.Equal("geh", result.Content);
+
+            Assert.Equal(789, result.Author.ID);
+            Assert.Equal("gaa", result.Author.Phone);
+            Assert.Equal("ghi", result.Author.Name);
+            Assert.Null(result.Author.Address);
+        }
+  
         public class Profile
         {
             public int ID { get; set; }

--- a/Dapper.Tests/MultiMapTests.cs
+++ b/Dapper.Tests/MultiMapTests.cs
@@ -597,7 +597,7 @@ Order by p.Id
                      cast('01 Feb 2013' as datetime) as CreateDate,
                      'ghi' as Name, 'def' as Phone",
             (T, P) => { T.Author = P; return T; },
-            null, null, true, "ID,ID").Single();
+            null, null, true, "ID,Name").Single();
 
             Assert.Equal(123, result.ID);
             Assert.Equal("abc", result.Title);

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1619,7 +1619,7 @@ namespace Dapper
                     int splitPoint = 0;
                     if (typeIdx > 0)
                     {
-                        splitPoint = GetNextSplit(currentPos, currentSplit, reader);
+                        splitPoint = GetNextSplit(currentPos, currentSplit, type.Name, reader);
                         if (isMultiSplit && splitIdx > 0)
                         {
                             currentSplit = splits[--splitIdx];
@@ -1659,7 +1659,7 @@ namespace Dapper
             return reader.FieldCount;
         }
 
-        private static int GetNextSplit(int startIdx, string splitOn, IDataReader reader)
+        private static int GetNextSplit(int startIdx, string splitOn, string typeName, IDataReader reader)
         {
             if (splitOn == "*")
             {
@@ -1668,7 +1668,8 @@ namespace Dapper
 
             for (var i = startIdx - 1; i > 0; --i)
             {
-                if (string.Equals(splitOn, reader.GetName(i), StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(splitOn, reader.GetName(i), StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(typeName + splitOn,  reader.GetName(i), StringComparison.OrdinalIgnoreCase))
                 {
                     return i;
                 }
@@ -3189,7 +3190,7 @@ namespace Dapper
 
             var members = IsValueTuple(type) ? GetValueTupleMembers(type, names) : ((specializedConstructor != null
                 ? names.Select(n => typeMap.GetConstructorParameter(specializedConstructor, n))
-                : names.Select(n => typeMap.GetMember(n))).ToList());
+                : names.Select(n => typeMap.GetMember(n) ?? typeMap.GetMember(n.Replace(type.Name,""))).ToList()));
 
             // stack is now [target]
 


### PR DESCRIPTION
Allows using the type name as an alias when returning records that may have columns that exist in both columns or database doesn't allow selecting a column name twice.

SELECT A.*, B.Id AS TableBId, B.Name AS TableBName
FROM
Table A
JOIN TableB B ON.....

Split ON "Id" (or split on TableBId)