### PR TITLE
Allow for DbCommand modification before execution

### DIFF
--- a/Dapper.Tests/CallbackTests.cs
+++ b/Dapper.Tests/CallbackTests.cs
@@ -11,7 +11,6 @@ namespace Dapper.Tests
     public class CallbackTests : TestBase
     {
         [Fact]
-        [Trait("Category", "aaa")]
         public void TestExecuteCallbackCommand()
         {
             IDbDataParameter r = null;
@@ -32,7 +31,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public async Task TestExecuteCallbackCommandAsync()
         {
             IDbDataParameter r = null;
@@ -53,7 +51,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public void TestExecuteScalerCallbackCommand()
         {
             IDbDataParameter r = null;
@@ -74,7 +71,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public async Task TestExecuteScalerCallbackCommandAsync()
         {
             IDbDataParameter r = null;
@@ -95,7 +91,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public void TestExecuteMultipleCallbackCommand()
         {
             connection.Execute("create table #tt(i int)");
@@ -122,7 +117,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public async Task TestExecuteMultipleCallbackCommandAsync()
         {
             connection.Execute("create table #tt(i int)");
@@ -149,7 +143,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public void TestExecuteReaderCallback()
         {
             IDbDataParameter r = null;
@@ -169,8 +162,7 @@ namespace Dapper.Tests
 
         }
         [Fact]
-        [Trait("Category", "aaa")]
-        public async Task TestExecuteReaderCallbackAsync()
+         public async Task TestExecuteReaderCallbackAsync()
         {
             IDbDataParameter r = null;
 
@@ -190,7 +182,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public void TestQueryCallback()
         {
             IDbDataParameter r = null;
@@ -211,7 +202,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public async Task TestQueryCallbackAsync()
         {
             IDbDataParameter r = null;
@@ -231,7 +221,6 @@ namespace Dapper.Tests
 
         }
         [Fact]
-        [Trait("Category", "aaa")]
         public void TestQueryMultipleCallback()
         {
             IDbDataParameter r = null;
@@ -252,7 +241,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public async Task TestQueryMultipleCallbackAsync()
         {
             IDbDataParameter r = null;
@@ -273,7 +261,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public void TestQueryFirstCallback()
         {
             IDbDataParameter r = null;
@@ -295,7 +282,6 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        [Trait("Category", "aaa")]
         public async Task TestQueryFirstCallbackAsync()
         {
             IDbDataParameter r = null;

--- a/Dapper.Tests/CallbackTests.cs
+++ b/Dapper.Tests/CallbackTests.cs
@@ -1,0 +1,320 @@
+﻿using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+
+namespace Dapper.Tests
+{
+    public class CallbackTests : TestBase
+    {
+        [Fact]
+        [Trait("Category", "aaa")]
+        public void TestExecuteCallbackCommand()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            connection.Execute(commandDef);
+
+            Assert.Equal(5, r.Value);
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public async Task TestExecuteCallbackCommandAsync()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            await connection.ExecuteAsync(commandDef);
+
+            Assert.Equal(5, r.Value);
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public void TestExecuteScalerCallbackCommand()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            connection.ExecuteScalar(commandDef);
+
+            Assert.Equal(5, r.Value);
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public async Task TestExecuteScalerCallbackCommandAsync()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            await connection.ExecuteScalarAsync(commandDef);
+
+            Assert.Equal(5, r.Value);
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public void TestExecuteMultipleCallbackCommand()
+        {
+            connection.Execute("create table #tt(i int)");
+            try
+            {
+                //Callback increases the value by one
+                var callback = new Action<IDbCommand>(cmd =>
+                {
+                    var p = (SqlParameter)cmd.Parameters[0];
+                    p.Value = ((int)p.Value) + 1;
+                });
+
+                var command = new CommandDefinition("insert #tt (i) values(@a)", new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 4 } }, beforeExecute: callback);
+                int tally = connection.Execute(command);
+                int sum = connection.Query<int>("select sum(i) from #tt").First();
+                Assert.Equal(4, tally);
+                Assert.Equal(14, sum);
+
+            }
+            finally
+            {
+                connection.Execute("drop table #tt");
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public async Task TestExecuteMultipleCallbackCommandAsync()
+        {
+            connection.Execute("create table #tt(i int)");
+            try
+            {
+                //Callback increases the value by one
+                var callback = new Action<IDbCommand>(cmd =>
+                {
+                    var p = (SqlParameter)cmd.Parameters[0];
+                    p.Value = ((int)p.Value) + 1;
+                });
+
+                var command = new CommandDefinition("insert #tt (i) values(@a)", new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 4 } }, beforeExecute: callback);
+                int tally = await connection.ExecuteAsync(command);
+                int sum = connection.Query<int>("select sum(i) from #tt").First();
+                Assert.Equal(4, tally);
+                Assert.Equal(14, sum);
+
+            }
+            finally
+            {
+                connection.Execute("drop table #tt");
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public void TestExecuteReaderCallback()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            connection.ExecuteReader(commandDef);
+            Assert.Equal(5, r.Value);
+
+        }
+        [Fact]
+        [Trait("Category", "aaa")]
+        public async Task TestExecuteReaderCallbackAsync()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            await connection.ExecuteReaderAsync(commandDef);
+            Assert.Equal(5, r.Value);
+
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public void TestQueryCallback()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            connection.Query<dynamic>(commandDef);
+            Assert.Equal(5, r.Value);
+
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public async Task TestQueryCallbackAsync()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            await connection.QueryAsync<dynamic>(commandDef);
+            Assert.Equal(5, r.Value);
+
+        }
+        [Fact]
+        [Trait("Category", "aaa")]
+        public void TestQueryMultipleCallback()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            connection.QueryMultiple(commandDef);
+            Assert.Equal(5, r.Value);
+
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public async Task TestQueryMultipleCallbackAsync()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            await  connection.QueryMultipleAsync(commandDef);
+            Assert.Equal(5, r.Value);
+
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public void TestQueryFirstCallback()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            connection.QueryFirstOrDefault<dynamic>(commandDef);
+            Assert.Equal(5, r.Value);
+
+
+        }
+
+        [Fact]
+        [Trait("Category", "aaa")]
+        public async Task TestQueryFirstCallbackAsync()
+        {
+            IDbDataParameter r = null;
+
+            var callback = new Action<IDbCommand>(cmd =>
+            {
+                r = cmd.CreateParameter();
+                r.ParameterName = "@R";
+                r.Direction = ParameterDirection.Output;
+                r.DbType = DbType.Int32;
+                cmd.Parameters.Add(r);
+            });
+
+            var commandDef = new CommandDefinition("select @R = Id from (select 5 as id) a", beforeExecute: callback);
+            await connection.QueryFirstOrDefaultAsync<dynamic>(commandDef);
+            Assert.Equal(5, r.Value);
+
+
+        }
+
+    }
+}

--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -74,6 +74,11 @@ namespace Dapper
         public bool Pipelined => (Flags & CommandFlags.Pipelined) != 0;
 
         /// <summary>
+        /// Action method called prior to the command executing.
+        /// </summary>
+        public Action<IDbCommand> BeforeExecute { get; }
+
+        /// <summary>
         /// Initialize the command definition
         /// </summary>
         /// <param name="commandText">The text for this command.</param>
@@ -83,9 +88,10 @@ namespace Dapper
         /// <param name="commandType">The <see cref="CommandType"/> for this command.</param>
         /// <param name="flags">The behavior flags for this command.</param>
         /// <param name="cancellationToken">The cancellation token for this command.</param>
+        /// <param name="beforeExecute">Callback action before the command is executed.</param>
         public CommandDefinition(string commandText, object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null,
                                  CommandType? commandType = null, CommandFlags flags = CommandFlags.Buffered
-                                 , CancellationToken cancellationToken = default(CancellationToken)
+                                 , CancellationToken cancellationToken = default(CancellationToken), Action<IDbCommand> beforeExecute = null
             )
         {
             CommandText = commandText;
@@ -95,6 +101,7 @@ namespace Dapper
             CommandType = commandType;
             Flags = flags;
             CancellationToken = cancellationToken;
+            BeforeExecute = beforeExecute;
         }
 
         private CommandDefinition(object parameters) : this()

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -416,6 +416,7 @@ namespace Dapper
                 try
                 {
                     if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
+                    command.BeforeExecute?.Invoke(cmd);
                     reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
 
                     var tuple = info.Deserializer;
@@ -480,6 +481,7 @@ namespace Dapper
                 try
                 {
                     if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
+                    command.BeforeExecute?.Invoke(cmd);
                     reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, (row & Row.Single) != 0
                     ? CommandBehavior.SequentialAccess | CommandBehavior.SingleResult // need to allow multiple rows, to check fail condition
                     : CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow, cancel).ConfigureAwait(false);
@@ -610,7 +612,7 @@ namespace Dapper
                                 cmd = command.TrySetupAsyncCommand(cnn, null);
                             }
                             info.ParamReader(cmd, obj);
-
+                            command.BeforeExecute?.Invoke(cmd);
                             var task = cmd.ExecuteNonQueryAsync(command.CancellationToken);
                             pending.Enqueue(new AsyncExecState(cmd, task));
                             cmd = null; // note the using in the finally: this avoids a double-dispose
@@ -651,6 +653,7 @@ namespace Dapper
                                 cmd.Parameters.Clear(); // current code is Add-tastic
                             }
                             info.ParamReader(cmd, obj);
+                            command.BeforeExecute?.Invoke(cmd);
                             total += await cmd.ExecuteNonQueryAsync(command.CancellationToken).ConfigureAwait(false);
                         }
                     }
@@ -675,6 +678,7 @@ namespace Dapper
                 try
                 {
                     if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                    command.BeforeExecute?.Invoke(cmd);
                     var result = await cmd.ExecuteNonQueryAsync(command.CancellationToken).ConfigureAwait(false);
                     command.OnCompleted();
                     return result;
@@ -1047,6 +1051,7 @@ namespace Dapper
             {
                 if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
                 cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+                command.BeforeExecute?.Invoke(cmd);
                 reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess, command.CancellationToken).ConfigureAwait(false);
 
                 var result = new GridReader(cmd, reader, identity, command.Parameters as DynamicParameters, command.AddToCache, command.CancellationToken);
@@ -1140,6 +1145,7 @@ namespace Dapper
             {
                 cmd = command.TrySetupAsyncCommand(cnn, paramReader);
                 if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                command.BeforeExecute?.Invoke(cmd);
                 var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, commandBehavior, command.CancellationToken).ConfigureAwait(false);
                 wasClosed = false;
                 return reader;
@@ -1214,6 +1220,7 @@ namespace Dapper
             {
                 cmd = command.TrySetupAsyncCommand(cnn, paramReader);
                 if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                command.BeforeExecute?.Invoke(cmd);
                 result = await cmd.ExecuteScalarAsync(command.CancellationToken).ConfigureAwait(false);
                 command.OnCompleted();
             }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -549,6 +549,7 @@ namespace Dapper
                                 cmd.Parameters.Clear(); // current code is Add-tastic
                             }
                             info.ParamReader(cmd, obj);
+                            command.BeforeExecute?.Invoke(cmd);
                             total += cmd.ExecuteNonQuery();
                         }
                     }
@@ -1019,6 +1020,7 @@ namespace Dapper
             {
                 if (wasClosed) cnn.Open();
                 cmd = command.SetupCommand(cnn, info.ParamReader);
+                command.BeforeExecute?.Invoke(cmd);
                 reader = ExecuteReaderWithFlagsFallback(cmd, wasClosed, CommandBehavior.SequentialAccess);
 
                 var result = new GridReader(cmd, reader, identity, command.Parameters as DynamicParameters, command.AddToCache);
@@ -1078,6 +1080,7 @@ namespace Dapper
                 cmd = command.SetupCommand(cnn, info.ParamReader);
 
                 if (wasClosed) cnn.Open();
+                command.BeforeExecute?.Invoke(cmd);
                 reader = ExecuteReaderWithFlagsFallback(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult);
                 wasClosed = false; // *if* the connection was closed and we got this far, then we now have a reader
                 // with the CloseConnection flag, so the reader will deal with the connection; we
@@ -1176,6 +1179,7 @@ namespace Dapper
                 cmd = command.SetupCommand(cnn, info.ParamReader);
 
                 if (wasClosed) cnn.Open();
+                command.BeforeExecute?.Invoke(cmd);
                 reader = ExecuteReaderWithFlagsFallback(cmd, wasClosed, (row & Row.Single) != 0
                     ? CommandBehavior.SequentialAccess | CommandBehavior.SingleResult // need to allow multiple rows, to check fail condition
                     : CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow);
@@ -2824,6 +2828,7 @@ namespace Dapper
             {
                 cmd = command.SetupCommand(cnn, paramReader);
                 if (wasClosed) cnn.Open();
+                command.BeforeExecute?.Invoke(cmd);
                 int result = cmd.ExecuteNonQuery();
                 command.OnCompleted();
                 return result;
@@ -2852,6 +2857,7 @@ namespace Dapper
             {
                 cmd = command.SetupCommand(cnn, paramReader);
                 if (wasClosed) cnn.Open();
+                command.BeforeExecute?.Invoke(cmd);
                 result = cmd.ExecuteScalar();
                 command.OnCompleted();
             }
@@ -2872,6 +2878,7 @@ namespace Dapper
             {
                 cmd = command.SetupCommand(cnn, paramReader);
                 if (wasClosed) cnn.Open();
+                command.BeforeExecute?.Invoke(cmd);
                 var reader = ExecuteReaderWithFlagsFallback(cmd, wasClosed, commandBehavior);
                 wasClosed = false; // don't dispose before giving it to them!
                 disposeCommand = false;


### PR DESCRIPTION
The main use case for this modification is to return values from an Oracle Insert/Update (like below) but this may allow for logging, modification of the command, modifying parameter types etc.

`insert into Person (FirstName, LastName) values (:FirstName, :LastName)  RETURNING IdentityId into :IdentityId`

For this query my callback switches the IdentityId parameter to Output.
see 
[My Oracle Adapter](https://github.com/dallasbeek/Dapper.Database/blob/oracle/Dapper.Database/Adapters/OracleAdapter.cs)