### PR TITLE
Fix: Inconsistent deserialisation between normal Query<T> and SqlMapper.Parse<T> #1111

### DIFF
--- a/Dapper.Tests/DataReaderTests.cs
+++ b/Dapper.Tests/DataReaderTests.cs
@@ -39,6 +39,16 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public void TestTreatIntAsABool()
+        {
+            // Test we are consistent with direct call to database, see TypeHandlerTests.TestTreatIntAsABool
+            using(var reader = connection.ExecuteReader("select CAST(1 AS BIT)"))
+                Assert.True(SqlMapper.Parse<bool>(reader).Single());
+            using (var reader = connection.ExecuteReader("select 1"))
+                Assert.True(SqlMapper.Parse<bool>(reader).Single());
+        }
+
+        [Fact]
         public void DiscriminatedUnion()
         {
             List<Discriminated_BaseType> result = new List<Discriminated_BaseType>();

--- a/Dapper.Tests/TypeHandlerTests.cs
+++ b/Dapper.Tests/TypeHandlerTests.cs
@@ -593,6 +593,13 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public void TestTreatIntAsABool()
+        {
+            Assert.True(connection.Query<bool>("select CAST(1 AS BIT)").Single());
+            Assert.True(connection.Query<bool>("select 1").Single());
+        }
+
+        [Fact]
         public void SO24607639_NullableBools()
         {
             var obj = connection.Query<HazBools>(

--- a/Dapper/SqlMapper.IDataReader.cs
+++ b/Dapper/SqlMapper.IDataReader.cs
@@ -15,10 +15,20 @@ namespace Dapper
         {
             if (reader.Read())
             {
-                var deser = GetDeserializer(typeof(T), reader, 0, -1, false);
+                var effectiveType = typeof(T);
+                var deser = GetDeserializer(effectiveType, reader, 0, -1, false);
+                var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
                 do
                 {
-                    yield return (T)deser(reader);
+                    object val = deser(reader);
+                    if (val == null || val is T)
+                    {
+                        yield return (T)val;
+                    }
+                    else
+                    {
+                        yield return (T)Convert.ChangeType(val, convertToType, System.Globalization.CultureInfo.InvariantCulture);
+                    }
                 } while (reader.Read());
             }
         }


### PR DESCRIPTION
Issue #1111: Inconsistent deserialisation between normal Query<T> and SqlMapper.Parse<T> 