### PR TITLE
Fixed issue #569 with IN and other condition.

### DIFF
--- a/Dapper.Tests/Providers/OLDEBTests.cs
+++ b/Dapper.Tests/Providers/OLDEBTests.cs
@@ -82,6 +82,22 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public void Issue569_SO38527197_PseudoPositionalParameters_In_And_Other_Condition()
+        {
+            const string sql = @"select s1.value as id, s2.value as score 
+                        from string_split('1,2,3,4,5',',') s1, string_split('1,2,3,4,5',',') s2
+                        where s1.value in ?ids? and s2.value = ?score?";
+            using (var connection = GetOleDbConnection())
+            {
+                const int score = 2;
+                int[] ids = { 1, 2, 5, 7 };
+                var list = connection.Query<int>(sql, new { ids, score }).AsList();
+                list.Sort();
+                Assert.Equal("1,2,5", string.Join(",", list));
+            }
+        }
+
+        [Fact]
         public void Issue569_SO38527197_PseudoPositionalParameters_In()
         {
             using (var connection = GetOleDbConnection())

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2101,11 +2101,11 @@ namespace Dapper
                             else
                             {
                                 var sb = GetStringBuilder().Append('(').Append(variableName);
-                                if (!byPosition) sb.Append(1);
+                                if (!byPosition) sb.Append(1); else sb.Append(namePrefix).Append(1).Append(variableName);
                                 for (int i = 2; i <= count; i++)
                                 {
                                     sb.Append(',').Append(variableName);
-                                    if (!byPosition) sb.Append(i);
+                                    if (!byPosition) sb.Append(i); else sb.Append(namePrefix).Append(i).Append(variableName);
                                 }
                                 return sb.Append(')').__ToStringRecycle();
                             }


### PR DESCRIPTION
Hello,

On issue #569 with IN statement and other condition Query() always fails because 'Replace' in 'PassByPosition' method (SqlMapper.cs) doesn't iterate over '?' character, and Clear() statement in 'firstMatch' condition delete all IN parameters. The result is 'wrong number of parameters' logically.

I created an issue a couple months ago #1025 but without any test, so i closed it.
Thanks for all and sorry for my english.