### PR TITLE
Improve Exception message

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -153,8 +153,7 @@ namespace Dapper.Contrib.Extensions
             var explicitKeys = ExplicitKeyPropertiesCache(type);
             var keyCount = keys.Count + explicitKeys.Count;
             if (keyCount > 1)
-                throw new DataException($"{method}<T> only supports an entity with a single [Key] or [ExplicitKey] property."+
-                " [Key] Count: ${keys.Count}, [ExplicitKey] Count: ${explicitKeys.Count}");
+                throw new DataException($"{method}<T> only supports an entity with a single [Key] or [ExplicitKey] property. [Key] Count: {keys.Count}, [ExplicitKey] Count: {explicitKeys.Count}");
             if (keyCount == 0)
                 throw new DataException($"{method}<T> only supports an entity with a [Key] or an [ExplicitKey] property");
 

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -153,7 +153,8 @@ namespace Dapper.Contrib.Extensions
             var explicitKeys = ExplicitKeyPropertiesCache(type);
             var keyCount = keys.Count + explicitKeys.Count;
             if (keyCount > 1)
-                throw new DataException($"{method}<T> only supports an entity with a single [Key] or [ExplicitKey] property");
+                throw new DataException($"{method}<T> only supports an entity with a single [Key] or [ExplicitKey] property."+
+                " [Key] Count: ${keys.Count}, [ExplicitKey] Count: ${explicitKeys.Count}");
             if (keyCount == 0)
                 throw new DataException($"{method}<T> only supports an entity with a [Key] or an [ExplicitKey] property");
 


### PR DESCRIPTION
In cases where the object has a property named ID, the property will automatically be assigned as [Key], even if [Computed] is added manually in an attempt to override it. This can cause confusion, this exception will be thrown despite the code looking fine and there only being one [ExplicitKey] defined. I've added this extra line of information to help diagnosis.