### PR TITLE
Fix Issue 798: Public Way To Get Currently Mapped DbType

### DIFF
--- a/Dapper.Tests/TypeHandlerTests.cs
+++ b/Dapper.Tests/TypeHandlerTests.cs
@@ -736,5 +736,29 @@ namespace Dapper.Tests
             public string SomeValue { get; }
             public Blarg SomeBlargValue { get; }
         }
+
+        [Fact]
+        public void Issue798_TestChangingDefaulTypeMappingUsingDbTypeLookup()
+        {
+            const string sql = "SELECT SQL_VARIANT_PROPERTY(CONVERT(sql_variant, @testParam),'BaseType') AS BaseType";
+            var param = new { testParam = "TestString" };
+
+            var result01 = connection.Query<string>(sql, param).FirstOrDefault();
+            Assert.Equal("nvarchar", result01);
+
+            SqlMapper.PurgeQueryCache();
+
+            DbType origType = SqlMapper.GetDbTypeForTypeMap(typeof(string));
+
+            SqlMapper.AddTypeMap(typeof(string), DbType.AnsiString);   // Change Default String Handling to AnsiString
+            var result02 = connection.Query<string>(sql, param).FirstOrDefault();
+            Assert.Equal("varchar", result02);
+
+            SqlMapper.PurgeQueryCache();
+            SqlMapper.AddTypeMap(typeof(string), origType);  // Restore Default to original type (Unicode String)
+
+            var result03 = connection.Query<string>(sql, param).FirstOrDefault();
+            Assert.Equal("nvarchar", result03);
+        }
     }
 }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -339,11 +339,25 @@ namespace Dapper
         /// <param name="handler">The handler for the type <typeparamref name="T"/>.</param>
         public static void AddTypeHandler<T>(TypeHandler<T> handler) => AddTypeHandlerImpl(typeof(T), handler, true);
 
+        /// <summary>
+        ///  Lookup the current DbType for a given TypeMap assigned to the Type.
+        /// </summary>
+        /// <param name="type">The type to lookup.</param>
+        /// <returns></returns>
+        public static DbType GetDbTypeForTypeMap(Type type)
+        {
+#pragma warning disable 618
+            return LookupDbType(type, "n/a", false, out ITypeHandler _);
+#pragma warning restore 618
+        }
+
         private static Dictionary<Type, ITypeHandler> typeHandlers;
 
         internal const string LinqBinary = "System.Data.Linq.Binary";
 
         private const string ObsoleteInternalUsageOnly = "This method is for internal use only";
+
+
 
         /// <summary>
         /// Get the DbType that maps to a given value.


### PR DESCRIPTION
Potential fix for #798.

This simply exposes one of the internal "obsolete" methods via a wrapper method.

This would allow someone to (for example) get the currently mapped DbType for some type, Add a new MapType and run some queries. Then, "reset" the map back to the original in a more dynamic way (without having to know what the original mapped type was).