### PR TITLE
Gets timeout from connection

### DIFF
--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -123,6 +123,10 @@ namespace Dapper
             {
                 cmd.CommandTimeout = SqlMapper.Settings.CommandTimeout.Value;
             }
+            else 
+            {
+                cmd.CommandTimeout = cnn.CommandTimeout;
+            }
             if (CommandType.HasValue)
                 cmd.CommandType = CommandType.Value;
             paramReader?.Invoke(cmd, Parameters);

--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -125,7 +125,7 @@ namespace Dapper
             }
             else 
             {
-                cmd.CommandTimeout = cnn.CommandTimeout;
+                cmd.CommandTimeout = cnn.ConnectionTimeout;
             }
             if (CommandType.HasValue)
                 cmd.CommandType = CommandType.Value;


### PR DESCRIPTION
Condition to obtain connection timeout, when it is not informed.

Reason: I have many connection strings, with the timeouts defined in the string, which change depending on the environment