### PR TITLE
Bump version to 1.60.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.50.8-alpha.{height}",
-  "assemblyVersion": "1.50.0.0",
+  "version": "1.60",
+  "assemblyVersion": "1.60.0.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d+\\.\\d+"


### PR DESCRIPTION
This bumps and locks at 1.60.0 to cope with whatever binding policies .NET Core is enforcing - then we can stick at this until 2.x I guess.