### PR TITLE
 Escape table names to resolve conflicts with reserved keywords 

### DIFF
--- a/Dapper.Tests/Providers/PostgresqlTests.cs
+++ b/Dapper.Tests/Providers/PostgresqlTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Dapper.Tests
 {
-    public class PostcresqlTests : TestBase
+    public class PostgresqlTests : TestBase
     {
         private static Npgsql.NpgsqlConnection GetOpenNpgsqlConnection()
         {


### PR DESCRIPTION
Table names are not being escaped in queries.  I added an EscapeArtifactName method to the ISqlAdapter interface, and used this method to escape table names.  Column names were already being escaped, but this fix updated columns to go through the same escape method.
