### PR TITLE
when the cache was created firstly, when it was returned, it must be …

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -165,7 +165,7 @@ namespace Dapper.Contrib.Extensions
             var name = GetTableName(type);
             var sbColumnList = new StringBuilder(null);
             var allProperties = TypePropertiesCache(type);
-            var keyProperties = KeyPropertiesCache(type).ToList();
+            var keyProperties = KeyPropertiesCache(type);
             var computedProperties = ComputedPropertiesCache(type);
             var allPropertiesExceptKeyAndComputed = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
 
@@ -232,7 +232,7 @@ namespace Dapper.Contrib.Extensions
                 }
             }
 
-            var keyProperties = KeyPropertiesCache(type).ToList();
+            var keyProperties = KeyPropertiesCache(type);
             var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
             if (keyProperties.Count == 0 && explicitKeyProperties.Count == 0)
                 throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -99,7 +99,7 @@ namespace Dapper.Contrib.Extensions
             var explicitKeyProperties = TypePropertiesCache(type).Where(p => p.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute)).ToList();
 
             ExplicitKeyProperties[type.TypeHandle] = explicitKeyProperties;
-            return explicitKeyProperties;
+            return explicitKeyProperties.ToList();
         }
 
         private static List<PropertyInfo> KeyPropertiesCache(Type type)
@@ -122,7 +122,7 @@ namespace Dapper.Contrib.Extensions
             }
 
             KeyProperties[type.TypeHandle] = keyProperties;
-            return keyProperties;
+            return keyProperties.ToList();
         }
 
         private static List<PropertyInfo> TypePropertiesCache(Type type)


### PR DESCRIPTION
…changed to new objects,avoid to be changed by outer code