### PR TITLE
KeyPropertyNameMapper for overriding "id" assumption for key property name

### DIFF
--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -81,6 +81,14 @@ namespace Dapper.Tests.Contrib
         public DateTime? Created { get; set; }
     }
 
+    [Table("Junk")]
+    public class Junk
+    {
+        public short JunkId { get; set; }
+        public string Name { get; set; }
+        public DateTime? Created { get; set; }
+    }
+
     [Table("Automobiles")]
     public class Car
     {
@@ -584,6 +592,32 @@ namespace Dapper.Tests.Contrib
                 var id = connection.Insert(new Person { Name = "Mr Mapper" });
                 Assert.Equal(1, id);
                 connection.GetAll<Person>();
+            }
+        }
+
+        [Fact]
+        public void InsertWithCustomKeyPropertyNameMapper()
+        {
+            SqlMapperExtensions.KeyPropertyNameMapper = type =>
+            {
+                switch (type.Name())
+                {
+                    case "Junk":
+                        var typeName = type.Name;
+                        var name = typeName + "Id";
+                        return name;
+
+                    default:
+                        return "id";
+                }
+            };
+
+            using (var connection = GetOpenConnection())
+            {
+                var id = connection.Insert(new Junk { Name = "Custom key mapper" });
+                Assert.Equal(1, id);
+                var junk = connection.Get<Junk>(id);
+                Assert.Equal(1, junk.JunkId);
             }
         }
 

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -91,6 +91,8 @@ namespace Dapper.Tests.Contrib
                     connection.Open();
                     dropTable("Stuff");
                     connection.Execute("CREATE TABLE Stuff (TheId int not null AUTO_INCREMENT PRIMARY KEY, Name nvarchar(100) not null, Created DateTime null);");
+                    dropTable("Junk");
+                    connection.Execute("CREATE TABLE Junk (JunkId int not null AUTO_INCREMENT PRIMARY KEY, Name nvarchar(100) not null, Created DateTime null);");
                     dropTable("People");
                     connection.Execute("CREATE TABLE People (Id int not null AUTO_INCREMENT PRIMARY KEY, Name nvarchar(100) not null);");
                     dropTable("Users");
@@ -137,6 +139,7 @@ namespace Dapper.Tests.Contrib
             {
                 connection.Open();
                 connection.Execute("CREATE TABLE Stuff (TheId integer primary key autoincrement not null, Name nvarchar(100) not null, Created DateTime null) ");
+                connection.Execute("CREATE TABLE Junk (JunkId integer primary key autoincrement not null, Name nvarchar(100) not null, Created DateTime null) ");
                 connection.Execute("CREATE TABLE People (Id integer primary key autoincrement not null, Name nvarchar(100) not null) ");
                 connection.Execute("CREATE TABLE Users (Id integer primary key autoincrement not null, Name nvarchar(100) not null, Age int not null) ");
                 connection.Execute("CREATE TABLE Automobiles (Id integer primary key autoincrement not null, Name nvarchar(100) not null) ");
@@ -169,6 +172,7 @@ namespace Dapper.Tests.Contrib
             {
                 connection.Open();
                 connection.Execute(@"CREATE TABLE Stuff (TheId int IDENTITY(1,1) not null, Name nvarchar(100) not null, Created DateTime null) ");
+                connection.Execute(@"CREATE TABLE Junk (JunkId int IDENTITY(1,1) not null, Name nvarchar(100) not null, Created DateTime null) ");
                 connection.Execute(@"CREATE TABLE People (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null) ");
                 connection.Execute(@"CREATE TABLE Users (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, Age int not null) ");
                 connection.Execute(@"CREATE TABLE Automobiles (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null) ");

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -26,12 +26,10 @@ namespace Dapper.Tests.Contrib
     public class SqlServerTestSuite : TestSuite
     {
         private const string DbName = "tempdb";
-
         public static string ConnectionString =>
             IsAppVeyor
                 ? @"Server=(local)\SQL2016;Database=tempdb;User ID=sa;Password=Password12!"
-                //: $"Data Source=.;Initial Catalog={DbName};Integrated Security=True";
-                : @"Data Source=tcp:PLADPDTAJENKS\ALEXTESTDATABASE,49172;Initial Catalog=TylerID;User Id=TEGadmin; Password=TEG$SQLadmin2; MultipleActiveResultSets=True";
+                : $"Data Source=.;Initial Catalog={DbName};Integrated Security=True";
         public override IDbConnection GetConnection() => new SqlConnection(ConnectionString);
 
         static SqlServerTestSuite()

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -26,10 +26,12 @@ namespace Dapper.Tests.Contrib
     public class SqlServerTestSuite : TestSuite
     {
         private const string DbName = "tempdb";
+
         public static string ConnectionString =>
             IsAppVeyor
                 ? @"Server=(local)\SQL2016;Database=tempdb;User ID=sa;Password=Password12!"
-                : $"Data Source=.;Initial Catalog={DbName};Integrated Security=True";
+                //: $"Data Source=.;Initial Catalog={DbName};Integrated Security=True";
+                : @"Data Source=tcp:PLADPDTAJENKS\ALEXTESTDATABASE,49172;Initial Catalog=TylerID;User Id=TEGadmin; Password=TEG$SQLadmin2; MultipleActiveResultSets=True";
         public override IDbConnection GetConnection() => new SqlConnection(ConnectionString);
 
         static SqlServerTestSuite()
@@ -41,6 +43,8 @@ namespace Dapper.Tests.Contrib
                 connection.Open();
                 dropTable("Stuff");
                 connection.Execute("CREATE TABLE Stuff (TheId int IDENTITY(1,1) not null, Name nvarchar(100) not null, Created DateTime null);");
+                dropTable("Junk");
+                connection.Execute("CREATE TABLE Junk (JunkId int IDENTITY(1,1) not null, Name nvarchar(100) not null, Created DateTime null);");
                 dropTable("People");
                 connection.Execute("CREATE TABLE People (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null);");
                 dropTable("Users");


### PR DESCRIPTION
We have a different naming convention for our identity columns and POCOs than Dapper.Contrib assumes.  There is a mechanism in place for resolving table names but not one for resolving the name of the ID column.