### PR TITLE
Expose the underlying connection from Rainbow Database so it's easier to use Dapper alongside other DB frameworks

### DIFF
--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -176,6 +176,11 @@ namespace Dapper
         private DbTransaction _transaction;
 
         /// <summary>
+        /// Get underlying database connection.
+        /// </summary>
+        public DbConnection Connection => _connection;
+
+        /// <summary>
         /// Initializes the database.
         /// </summary>
         /// <param name="connection">The connection to use.</param>


### PR DESCRIPTION
https://github.com/StackExchange/Dapper/issues/1253