### PR TITLE
Issue #1234 - TypeHandler: Allow modification of parameter when value is null

### DIFF
--- a/Dapper/SqlMapper.TypeHandler.cs
+++ b/Dapper/SqlMapper.TypeHandler.cs
@@ -19,6 +19,16 @@ namespace Dapper
             public abstract void SetValue(IDbDataParameter parameter, T value);
 
             /// <summary>
+            /// Assign the parameter value when the parameter is null
+            /// </summary>
+            /// <param name="parameter">The parameter to configure</param>
+            /// <remarks>The parameter's <see cref="DbType"/> will default to <see cref="DbType.String"/> if not changed</remarks>
+            public virtual void SetNullValue(IDbDataParameter parameter)
+            {
+                parameter.Value = DBNull.Value;
+            }
+
+            /// <summary>
             /// Parse a database value back to a typed value
             /// </summary>
             /// <param name="value">The value from the database</param>
@@ -29,7 +39,7 @@ namespace Dapper
             {
                 if (value is DBNull)
                 {
-                    parameter.Value = value;
+                    SetNullValue(parameter);
                 }
                 else
                 {


### PR DESCRIPTION
Provides a workaround for #1234.

In short, implementers of `SqlMapper.TypeHandler<T>` don't have the chance to set `DbType` for a null database parameter of type `T`. `DbType` seems to default to `DbType.String`, and this will cause (for example) an `INSERT` into a `VARBINARY` column to fail with the error `Implicit conversion from data type nvarchar to varbinary is not allowed. Use the CONVERT function to run this query.`.

Modifying `ITypeHandler.SetValue` to call `SetValue` even when the value is `DbNull` would be a breaking change for existing code that expects only non-null values, so my fix is to add a `SetNullValue` method which can optionally be overridden so that `DbType` can be modified.