### PR TITLE
Changing Insert<T> method internal usage of int to long

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -376,7 +376,7 @@ namespace Dapper.Contrib.Extensions
                     sbParameterList.Append(", ");
             }
 
-            int returnVal;
+            long returnVal;
             var wasClosed = connection.State == ConnectionState.Closed;
             if (wasClosed) connection.Open();
 


### PR DESCRIPTION
Changed the internal workings of this method so that method signature actually aligns with the inner workings.

Additional info: Problem was discovered in production in a large db, when a table passed more than 2147483647 inserted rows.