### PR TITLE
Support of PostgreSQL arrays

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1767,6 +1767,19 @@ namespace Dapper
             });
         }
 
+        private static bool IsRegisteredType(Type type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            Type underlyingType = null;
+
+            return typeMap.ContainsKey(type) || type.IsEnum() || type.FullName == LinqBinary
+                   || (type.IsValueType() && (underlyingType = Nullable.GetUnderlyingType(type)) != null && underlyingType.IsEnum());
+        }
+
         private static Func<IDataReader, object> GetDeserializer(Type type, IDataReader reader, int startBound, int length, bool returnNullIfFirstMissing)
         {
             // dynamic is passed in as Object ... by c# design
@@ -1775,8 +1788,7 @@ namespace Dapper
                 return GetDapperRowDeserializer(reader, startBound, length, returnNullIfFirstMissing);
             }
             Type underlyingType = null;
-            if (!(typeMap.ContainsKey(type) || type.IsEnum() || type.FullName == LinqBinary
-                || (type.IsValueType() && (underlyingType = Nullable.GetUnderlyingType(type)) != null && underlyingType.IsEnum())))
+            if (!(IsRegisteredType(type) || (type.IsArray && IsRegisteredType(type.GetElementType()))))
             {
                 if (typeHandlers.TryGetValue(type, out ITypeHandler handler))
                 {


### PR DESCRIPTION
There are [array types in PostgreSQL](https://www.postgresql.org/docs/11/arrays.html)

Array are supported by Npgsql. e.g. we have a model class:
`public class Model {`
`  public int Id { get; set; }`
`  public int[] Data { get; set; }`
`}`

Now it's possible to do with Dapper:
`string sql = "select n0.* from public.number_array n0 where 11 = any(n0.data)";`
`var result = conn.Query<Model>(sql).ToList();`
Array member is mapped right way.

But if we try to specify this member in SQL and set array as result type:
`string sql = "select n0.data from public.number_array n0 where 11 = any(n0.data)";`
`var result = conn.Query<int[]>(sql).ToList();`
then we get an ArgumentException.

The reason is GetDeserializer choses GetTypeDeserializer instead of GetStructDeserializer for array type. I tried to include arrays in 'known types' on checking and it runs on.