### PR TITLE
Handle PostgreSQL chars correctly

### DIFF
--- a/Dapper.Tests/Providers/PostgresqlTests.cs
+++ b/Dapper.Tests/Providers/PostgresqlTests.cs
@@ -56,6 +56,28 @@ namespace Dapper.Tests
             }
         }
 
+        private class CharTable
+        {
+            public int Id { get; set; }
+            public char CharColumn { get; set; }
+        }
+
+        [FactPostgresql]
+        public void TestPostgresqlChar()
+        {
+            using (var conn = GetOpenNpgsqlConnection())
+            {
+                var transaction = conn.BeginTransaction();
+                conn.Execute("create table chartable (id serial not null, charcolumn \"char\" not null);");
+                conn.Execute("insert into chartable(charcolumn) values('a');");
+
+                var r = conn.Query<CharTable>("select * from chartable");
+                Assert.Single(r);
+                Assert.Equal('a', r.Single().CharColumn);
+                transaction.Rollback();
+            }
+        }
+
         [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
         public class FactPostgresqlAttribute : FactAttribute
         {

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1876,6 +1876,8 @@ namespace Dapper
         public static char ReadChar(object value)
         {
             if (value == null || value is DBNull) throw new ArgumentNullException(nameof(value));
+            var c = value as char?;
+            if (c != null) return c.Value;
             var s = value as string;
             if (s == null || s.Length != 1) throw new ArgumentException("A single-character was expected", nameof(value));
             return s[0];
@@ -1891,6 +1893,8 @@ namespace Dapper
         public static char? ReadNullableChar(object value)
         {
             if (value == null || value is DBNull) return null;
+            var c = value as char?;
+            if (c != null) return c;
             var s = value as string;
             if (s == null || s.Length != 1) throw new ArgumentException("A single-character was expected", nameof(value));
             return s[0];

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1876,11 +1876,14 @@ namespace Dapper
         public static char ReadChar(object value)
         {
             if (value == null || value is DBNull) throw new ArgumentNullException(nameof(value));
-            var c = value as char?;
-            if (c != null) return c.Value;
             var s = value as string;
-            if (s == null || s.Length != 1) throw new ArgumentException("A single-character was expected", nameof(value));
-            return s[0];
+            if (s == null)
+            {
+                var c = value as char?;
+                if (c != null) return c.Value;
+            }
+            else if (s.Length == 1) return s[0];
+            throw new ArgumentException("A single-character was expected", nameof(value));
         }
 
         /// <summary>
@@ -1893,11 +1896,14 @@ namespace Dapper
         public static char? ReadNullableChar(object value)
         {
             if (value == null || value is DBNull) return null;
-            var c = value as char?;
-            if (c != null) return c;
             var s = value as string;
-            if (s == null || s.Length != 1) throw new ArgumentException("A single-character was expected", nameof(value));
-            return s[0];
+            if (s == null)
+            {
+                var c = value as char?;
+                if (c != null) return c;
+            }
+            else if (s.Length == 1) return s[0];
+            throw new ArgumentException("A single-character was expected", nameof(value));
         }
 
         /// <summary>


### PR DESCRIPTION
PostgreSQL columns with type `"char"` are read by `NpgsqlDataReader` as .NET `char`s. However, current implementation of `SqlMapper.ReadChar` expects `DbDataReader`s to read characters as .NET `string`s.