### PR TITLE
Fix performance tests

### DIFF
--- a/Dapper.Tests.Performance/Benchmarks.cs
+++ b/Dapper.Tests.Performance/Benchmarks.cs
@@ -6,7 +6,6 @@ using System.Data.SqlClient;
 
 namespace Dapper.Tests.Performance
 {
-    [Orderer(SummaryOrderPolicy.FastestToSlowest)]
     [BenchmarkCategory("ORM")]
     public abstract class BenchmarkBase
     {

--- a/Dapper.Tests.Performance/Config.cs
+++ b/Dapper.Tests.Performance/Config.cs
@@ -31,7 +31,7 @@ namespace Dapper.Tests.Performance
             //Add(StatisticColumn.StdDev);
             //Add(StatisticColumn.Error);
             Add(BaselineRatioColumn.RatioMean);
-            //Add(md.GetColumnProvider());
+            Add(DefaultColumnProviders.Metrics);
 
             Add(Job.ShortRun
                    .WithLaunchCount(1)


### PR DESCRIPTION
Hi!
This PR tries to fix Dapper.Performance.Tests, actually you can't get [MemoryDiagnoser](https://benchmarkdotnet.org/api/BenchmarkDotNet.Diagnosers.MemoryDiagnoser.html)  stats because 
```IDiagnoser.GetColumnProvider()``` method was gone on BenchmarkDotnet 0.11.2. I choose ```DefaultColumnProviders.Metrics``` because of [this](https://github.com/dotnet/BenchmarkDotNet/issues/1184#issuecomment-507377695), i think it's the most simple way to add stats now.

**Before**
![image](https://user-images.githubusercontent.com/34173061/65264060-1a5f7780-db0e-11e9-9c8c-bb4c69a808df.png)

**After**
![image](https://user-images.githubusercontent.com/34173061/65264158-4f6bca00-db0e-11e9-9313-597b09070ae6.png)

On the other hand i choose removing ```[Ordered]``` as temporal solution of https://github.com/dotnet/BenchmarkDotNet/issues/1238, and yeah, the results are still ordered because of https://github.com/StackExchange/Dapper/blob/9282ef2872e1c82c68c86f31e93e8f1ceaacd409/Dapper.Tests.Performance/Config.cs#L42

**Before**
![image](https://user-images.githubusercontent.com/34173061/65264660-6232ce80-db0f-11e9-9046-9c2d8fc5e2d8.png)

**After**
😄 (No errors)

Thanks for all!!