### PR TITLE
Fix arguments for String.Format

### DIFF
--- a/Dapper.Tests.Performance/Massive/Massive.cs
+++ b/Dapper.Tests.Performance/Massive/Massive.cs
@@ -431,7 +431,7 @@ namespace Massive
                     where = "WHERE " + where;
                 }
             }
-            var sql = string.Format("SELECT {0} FROM (SELECT ROW_NUMBER() OVER (ORDER BY {2}) AS Row, {0} FROM {3} {4}) AS Paged ", columns, pageSize, orderBy, TableName, where);
+            var sql = string.Format("SELECT {0} FROM (SELECT ROW_NUMBER() OVER (ORDER BY {1}) AS Row, {0} FROM {2} {3}) AS Paged ", columns, orderBy, TableName, where);
             var pageStart = (currentPage - 1) * pageSize;
             sql += string.Format(" WHERE Row >={0} AND Row <={1}", pageStart, pageStart + pageSize);
             countSQL += where;


### PR DESCRIPTION
Removed pageSize because it is not used in string.format