### PR TITLE
MultiExecute don't need repeat set CommandText

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -531,19 +531,16 @@ namespace Dapper
                     if (wasClosed) cnn.Open();
                     using (var cmd = command.SetupCommand(cnn, null))
                     {
-                        string masterSql = null;
                         foreach (var obj in multiExec)
                         {
                             if (isFirst)
                             {
-                                masterSql = cmd.CommandText;
                                 isFirst = false;
                                 identity = new Identity(command.CommandText, cmd.CommandType, cnn, null, obj.GetType());
                                 info = GetCacheInfo(identity, obj, command.AddToCache);
                             }
                             else
                             {
-                                cmd.CommandText = masterSql; // because we do magic replaces on "in" etc
                                 cmd.Parameters.Clear(); // current code is Add-tastic
                             }
                             info.ParamReader(cmd, obj);


### PR DESCRIPTION
Issue : MultiExecute don't need repeat set CommandText #1344

https://github.com/StackExchange/Dapper/blob/247e498f0e52c88d0c58c6f1fa50457bb6ab5888/Dapper/SqlMapper.cs#L546

Because it use same DbCommand.   
Is there a chance to delete it? there is some efficiency in a large number of executes

![image](https://user-images.githubusercontent.com/12729184/66030515-1b43d080-e534-11e9-89df-3202604e078d.png)

