### PR TITLE
Add installation instructions when using .NET CLI instead of nuget.exe

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ Questions on Stack Overflow should be tagged [`dapper`](https://stackoverflow.co
 
 From NuGet:
 
+### Using Package Manager
+
     Install-Package Dapper
 
 or
@@ -17,6 +19,14 @@ or
     Install-Package Dapper.StrongName
 
 Note: to get the latest pre-release build, add ` -Pre` to the end of the command.
+
+### Using .NET CLI
+
+    dotnet add package Dapper
+
+or
+
+    dotnet add package Dapper.StrongName
 
 ## Release  Notes
 


### PR DESCRIPTION
Note I haven't found a way to port -Pre(release) to dotnet add, so I didn't add that instruction.