### PR TITLE
Added EF6 performance tests back in netcoreapp3.0

### DIFF
--- a/Dapper.Tests.Performance/Benchmarks.EntityFramework.cs
+++ b/Dapper.Tests.Performance/Benchmarks.EntityFramework.cs
@@ -1,5 +1,4 @@
-﻿#if NET4X
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using System.ComponentModel;
 using System.Linq;
 
@@ -39,4 +38,3 @@ namespace Dapper.Tests.Performance
         }
     }
 }
-#endif

--- a/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
+++ b/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
@@ -31,6 +31,10 @@
     <Compile Update="Benchmarks.*.cs" DependentUpon="Benchmarks.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="EntityFramework" Version="6.3.0" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
     <DefineConstants>$(DefineConstants);NET4X</DefineConstants>
   </PropertyGroup>

--- a/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
+++ b/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Include="DevExpress.Xpo" Version="19.1.5" />
     <!--<PackageReference Include="BLToolkit" Version="4.3.6" />-->
+    <PackageReference Include="EntityFramework" Version="6.3.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.0.0" />
     <PackageReference Include="linq2db.SqlServer" Version="2.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
@@ -31,16 +32,11 @@
     <Compile Update="Benchmarks.*.cs" DependentUpon="Benchmarks.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <PackageReference Include="EntityFramework" Version="6.3.0" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
     <DefineConstants>$(DefineConstants);NET4X</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <ProjectReference Include="..\Dapper.EntityFramework\Dapper.EntityFramework.csproj" />
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
     <PackageReference Include="Soma" Version="1.9.0.1" />
     <PackageReference Include="SubSonic" Version="3.0.0.4" />

--- a/Dapper.Tests.Performance/EntityFramework/EFContext.cs
+++ b/Dapper.Tests.Performance/EntityFramework/EFContext.cs
@@ -1,5 +1,4 @@
-﻿#if NET4X
-using System.Data.Common;
+﻿using System.Data.Common;
 using System.Data.Entity;
 
 namespace Dapper.Tests.Performance.EntityFramework
@@ -13,4 +12,3 @@ namespace Dapper.Tests.Performance.EntityFramework
         public DbSet<Post> Posts { get; set; }
     }
 }
-#endif

--- a/Dapper.Tests.Performance/LegacyTests.cs
+++ b/Dapper.Tests.Performance/LegacyTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Belgrade.SqlClient;
 using Dapper.Contrib.Extensions;
 using Dapper.Tests.Performance.Dashing;
+using Dapper.Tests.Performance.EntityFramework;
 using Dapper.Tests.Performance.EntityFrameworkCore;
 using Dapper.Tests.Performance.NHibernate;
 using Dashing;
@@ -22,7 +23,6 @@ using System.Configuration;
 using System.Threading.Tasks;
 #if NET4X
 using System.Data.Linq;
-using Dapper.Tests.Performance.EntityFramework;
 using Dapper.Tests.Performance.Linq2Sql;
 using Dapper.Tests.Performance.Xpo;
 using NHibernate.Linq;
@@ -343,7 +343,6 @@ namespace Dapper.Tests.Performance
                     }, "DevExpress.XPO: FindObject<T>");
                 }, "DevExpress.XPO");
 
-#if NET4X
                 // Entity Framework
                 Try(() =>
                 {
@@ -357,6 +356,7 @@ namespace Dapper.Tests.Performance
                     tests.Add(id => entityContext3.Posts.AsNoTracking().First(p => p.Id == id), "Entity Framework: No Tracking");
                 }, "Entity Framework");
 
+#if NET4X
                 // Linq2SQL
                 Try(() =>
                 {


### PR DESCRIPTION
Entity Framework 6 is now available again in netcoreapp3.0 since version 6.3.

Added performance tests for EF6 again when targeting netcoreapp3.0.