### PR TITLE
Annotate nullability on public APIs

### DIFF
--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading;
 
+#nullable enable
+
 namespace Dapper
 {
     /// <summary>
@@ -11,7 +13,7 @@ namespace Dapper
     /// </summary>
     public struct CommandDefinition
     {
-        internal static CommandDefinition ForCallback(object parameters)
+        internal static CommandDefinition ForCallback(object? parameters)
         {
             if (parameters is DynamicParameters)
             {
@@ -36,12 +38,12 @@ namespace Dapper
         /// <summary>
         /// The parameters associated with the command
         /// </summary>
-        public object Parameters { get; }
+        public object? Parameters { get; }
 
         /// <summary>
         /// The active transaction for the command
         /// </summary>
-        public IDbTransaction Transaction { get; }
+        public IDbTransaction? Transaction { get; }
 
         /// <summary>
         /// The effective timeout for the command
@@ -83,7 +85,7 @@ namespace Dapper
         /// <param name="commandType">The <see cref="CommandType"/> for this command.</param>
         /// <param name="flags">The behavior flags for this command.</param>
         /// <param name="cancellationToken">The cancellation token for this command.</param>
-        public CommandDefinition(string commandText, object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null,
+        public CommandDefinition(string commandText, object? parameters = null, IDbTransaction? transaction = null, int? commandTimeout = null,
                                  CommandType? commandType = null, CommandFlags flags = CommandFlags.Buffered
                                  , CancellationToken cancellationToken = default(CancellationToken)
             )
@@ -107,7 +109,7 @@ namespace Dapper
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
-        internal IDbCommand SetupCommand(IDbConnection cnn, Action<IDbCommand, object> paramReader)
+        internal IDbCommand SetupCommand(IDbConnection cnn, Action<IDbCommand, object?>? paramReader)
         {
             var cmd = cnn.CreateCommand();
             var init = GetInit(cmd.GetType());
@@ -129,13 +131,13 @@ namespace Dapper
             return cmd;
         }
 
-        private static SqlMapper.Link<Type, Action<IDbCommand>> commandInitCache;
+        private static SqlMapper.Link<Type, Action<IDbCommand>?>? commandInitCache;
 
-        private static Action<IDbCommand> GetInit(Type commandType)
+        private static Action<IDbCommand>? GetInit(Type? commandType)
         {
             if (commandType == null)
                 return null; // GIGO
-            if (SqlMapper.Link<Type, Action<IDbCommand>>.TryGet(commandInitCache, commandType, out Action<IDbCommand> action))
+            if (SqlMapper.Link<Type, Action<IDbCommand>?>.TryGet(commandInitCache, commandType, out Action<IDbCommand>? action))
             {
                 return action;
             }
@@ -168,11 +170,11 @@ namespace Dapper
                 action = (Action<IDbCommand>)method.CreateDelegate(typeof(Action<IDbCommand>));
             }
             // cache it
-            SqlMapper.Link<Type, Action<IDbCommand>>.TryAdd(ref commandInitCache, commandType, ref action);
+            SqlMapper.Link<Type, Action<IDbCommand>?>.TryAdd(ref commandInitCache, commandType, ref action);
             return action;
         }
 
-        private static MethodInfo GetBasicPropertySetter(Type declaringType, string name, Type expectedType)
+        private static MethodInfo? GetBasicPropertySetter(Type declaringType, string name, Type expectedType)
         {
             var prop = declaringType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
             if (prop?.CanWrite == true && prop.PropertyType == expectedType && prop.GetIndexParameters().Length == 0)

--- a/Dapper/CustomPropertyTypeMap.cs
+++ b/Dapper/CustomPropertyTypeMap.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Reflection;
 
+#nullable enable
+
 namespace Dapper
 {
     /// <summary>
@@ -28,14 +30,14 @@ namespace Dapper
         /// <param name="names">DataReader column names</param>
         /// <param name="types">DataReader column types</param>
         /// <returns>Default constructor</returns>
-        public ConstructorInfo FindConstructor(string[] names, Type[] types) =>
+        public ConstructorInfo? FindConstructor(string[] names, Type[] types) =>
             _type.GetConstructor(new Type[0]);
 
         /// <summary>
         /// Always returns null
         /// </summary>
         /// <returns></returns>
-        public ConstructorInfo FindExplicitConstructor() => null;
+        public ConstructorInfo? FindExplicitConstructor() => null;
 
         /// <summary>
         /// Not implemented as far as default constructor used for all cases
@@ -53,7 +55,7 @@ namespace Dapper
         /// </summary>
         /// <param name="columnName">DataReader column name</param>
         /// <returns>Poperty member map</returns>
-        public SqlMapper.IMemberMap GetMember(string columnName)
+        public SqlMapper.IMemberMap? GetMember(string columnName)
         {
             var prop = _propertySelector(_type, columnName);
             return prop != null ? new SimpleMemberMap(columnName, prop) : null;

--- a/Dapper/DbString.cs
+++ b/Dapper/DbString.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     /// <summary>
@@ -43,12 +45,12 @@ namespace Dapper
         /// <summary>
         /// The value of the string
         /// </summary>
-        public string Value { get; set; }
+        public string? Value { get; set; }
         /// <summary>
         /// Add the parameter to the command... internal use only
         /// </summary>
         /// <param name="command"></param>
-        /// <param name="name"></param>
+        /// <param name="name"></param>A
         public void AddParameter(IDbCommand command, string name)
         {
             if (IsFixedLength && Length == -1)

--- a/Dapper/DefaultTypeMap.cs
+++ b/Dapper/DefaultTypeMap.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
+#nullable enable
+
 namespace Dapper
 {
     /// <summary>
@@ -27,17 +29,17 @@ namespace Dapper
             _type = type;
         }
 
-        internal static MethodInfo GetPropertySetter(PropertyInfo propertyInfo, Type type)
+        internal static MethodInfo? GetPropertySetter(PropertyInfo propertyInfo, Type type)
         {
             if (propertyInfo.DeclaringType == type) return propertyInfo.GetSetMethod(true);
 
-            return propertyInfo.DeclaringType.GetProperty(
+            return propertyInfo.DeclaringType?.GetProperty(
                    propertyInfo.Name,
                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                    Type.DefaultBinder,
                    propertyInfo.PropertyType,
                    propertyInfo.GetIndexParameters().Select(p => p.ParameterType).ToArray(),
-                   null).GetSetMethod(true);
+                   null)?.GetSetMethod(true);
         }
 
         internal static List<PropertyInfo> GetSettableProps(Type t)
@@ -59,7 +61,7 @@ namespace Dapper
         /// <param name="names">DataReader column names</param>
         /// <param name="types">DataReader column types</param>
         /// <returns>Matching constructor or default one</returns>
-        public ConstructorInfo FindConstructor(string[] names, Type[] types)
+        public ConstructorInfo? FindConstructor(string[] names, Type[] types)
         {
             var constructors = _type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             foreach (ConstructorInfo ctor in constructors.OrderBy(c => c.IsPublic ? 0 : (c.IsPrivate ? 2 : 1)).ThenBy(c => c.GetParameters().Length))
@@ -98,7 +100,7 @@ namespace Dapper
         /// <summary>
         /// Returns the constructor, if any, that has the ExplicitConstructorAttribute on it.
         /// </summary>
-        public ConstructorInfo FindExplicitConstructor()
+        public ConstructorInfo? FindExplicitConstructor()
         {
             var constructors = _type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             var withAttr = constructors.Where(c => c.GetCustomAttributes(typeof(ExplicitConstructorAttribute), true).Length > 0).ToList();
@@ -129,7 +131,7 @@ namespace Dapper
         /// </summary>
         /// <param name="columnName">DataReader column name</param>
         /// <returns>Mapping implementation</returns>
-        public SqlMapper.IMemberMap GetMember(string columnName)
+        public SqlMapper.IMemberMap? GetMember(string columnName)
         {
             var property = Properties.Find(p => string.Equals(p.Name, columnName, StringComparison.Ordinal))
                ?? Properties.Find(p => string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase));

--- a/Dapper/ExplicitConstructorAttribute.cs
+++ b/Dapper/ExplicitConstructorAttribute.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+#nullable enable
+
 namespace Dapper
 {
     /// <summary>

--- a/Dapper/Extensions.cs
+++ b/Dapper/Extensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Dapper
 {
     internal static class Extensions
@@ -22,10 +24,10 @@ namespace Dapper
             return source.Task;
         }
 
-        private static void OnTaskCompleted<TFrom, TTo>(Task<TFrom> completedTask, object state)
+        private static void OnTaskCompleted<TFrom, TTo>(Task<TFrom> completedTask, object? state)
             where TFrom : TTo
         {
-            var source = (TaskCompletionSource<TTo>)state;
+            var source = (TaskCompletionSource<TTo>)state!;
 
             switch (completedTask.Status)
             {
@@ -36,7 +38,7 @@ namespace Dapper
                     source.SetCanceled();
                     break;
                 case TaskStatus.Faulted:
-                    source.SetException(completedTask.Exception.InnerExceptions);
+                    source.SetException(completedTask.Exception!.InnerExceptions);
                     break;
             }
         }

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -22,7 +24,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         /// <remarks>Note: each row can be accessed via "dynamic", or by casting to an IDictionary&lt;string,object&gt;</remarks>
-        public static Task<IEnumerable<dynamic>> QueryAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IEnumerable<dynamic>> QueryAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryAsync<dynamic>(cnn, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default(CancellationToken)));
 
         /// <summary>
@@ -84,7 +86,7 @@ namespace Dapper
         /// A sequence of data of <typeparamref name="T"/>; if a basic type (int, string, etc) is queried then the data from the first column in assumed, otherwise an instance is
         /// created per row, and a direct column-name===member-name mapping is assumed (case insensitive).
         /// </returns>
-        public static Task<IEnumerable<T>> QueryAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IEnumerable<T>> QueryAsync<T>(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryAsync<T>(cnn, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default(CancellationToken)));
 
         /// <summary>
@@ -97,7 +99,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
-        public static Task<T> QueryFirstAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<T> QueryFirstAsync<T>(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryRowAsync<T>(cnn, Row.First, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
 
         /// <summary>
@@ -110,7 +112,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
-        public static Task<T> QueryFirstOrDefaultAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<T> QueryFirstOrDefaultAsync<T>(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryRowAsync<T>(cnn, Row.FirstOrDefault, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
 
         /// <summary>
@@ -123,7 +125,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
-        public static Task<T> QuerySingleAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<T> QuerySingleAsync<T>(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryRowAsync<T>(cnn, Row.Single, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
 
         /// <summary>
@@ -136,7 +138,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
-        public static Task<T> QuerySingleOrDefaultAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<T> QuerySingleOrDefaultAsync<T>(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryRowAsync<T>(cnn, Row.SingleOrDefault, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
 
         /// <summary>
@@ -148,7 +150,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
-        public static Task<dynamic> QueryFirstAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<dynamic> QueryFirstAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryRowAsync<dynamic>(cnn, Row.First, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
 
         /// <summary>
@@ -160,7 +162,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
-        public static Task<dynamic> QueryFirstOrDefaultAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<dynamic> QueryFirstOrDefaultAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryRowAsync<dynamic>(cnn, Row.FirstOrDefault, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
 
         /// <summary>
@@ -172,7 +174,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
-        public static Task<dynamic> QuerySingleAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<dynamic> QuerySingleAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryRowAsync<dynamic>(cnn, Row.Single, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
 
         /// <summary>
@@ -184,7 +186,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
-        public static Task<dynamic> QuerySingleOrDefaultAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<dynamic> QuerySingleOrDefaultAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryRowAsync<dynamic>(cnn, Row.SingleOrDefault, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
 
         /// <summary>
@@ -198,7 +200,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
-        public static Task<IEnumerable<object>> QueryAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<object>> QueryAsync(this IDbConnection cnn, Type type, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
             return QueryAsync<object>(cnn, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default(CancellationToken)));
@@ -215,7 +217,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
-        public static Task<object> QueryFirstAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QueryFirstAsync(this IDbConnection cnn, Type type, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
             return QueryRowAsync<object>(cnn, Row.First, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
@@ -231,7 +233,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
-        public static Task<object> QueryFirstOrDefaultAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QueryFirstOrDefaultAsync(this IDbConnection cnn, Type type, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
             return QueryRowAsync<object>(cnn, Row.FirstOrDefault, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
@@ -247,7 +249,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
-        public static Task<object> QuerySingleAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QuerySingleAsync(this IDbConnection cnn, Type type, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
             return QueryRowAsync<object>(cnn, Row.Single, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
@@ -263,7 +265,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
-        public static Task<object> QuerySingleOrDefaultAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QuerySingleOrDefaultAsync(this IDbConnection cnn, Type type, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
             return QueryRowAsync<object>(cnn, Row.SingleOrDefault, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
@@ -366,7 +368,7 @@ namespace Dapper
         private static Task<DbDataReader> ExecuteReaderWithFlagsFallbackAsync(DbCommand cmd, bool wasClosed, CommandBehavior behavior, CancellationToken cancellationToken)
         {
             var task = cmd.ExecuteReaderAsync(GetBehavior(wasClosed, behavior), cancellationToken);
-            if (task.Status == TaskStatus.Faulted && Settings.DisableCommandBehaviorOptimizations(behavior, task.Exception.InnerException))
+            if (task.Status == TaskStatus.Faulted && Settings.DisableCommandBehaviorOptimizations(behavior, task.Exception!.InnerException))
             { // we can retry; this time it will have different flags
                 return cmd.ExecuteReaderAsync(GetBehavior(wasClosed, behavior), cancellationToken);
             }
@@ -391,7 +393,7 @@ namespace Dapper
         /// <summary>
         /// Attempts setup a <see cref="DbCommand"/> on a <see cref="DbConnection"/>, with a better error message for unsupported usages.
         /// </summary>
-        private static DbCommand TrySetupAsyncCommand(this CommandDefinition command, IDbConnection cnn, Action<IDbCommand, object> paramReader)
+        private static DbCommand TrySetupAsyncCommand(this CommandDefinition command, IDbConnection cnn, Action<IDbCommand, object?>? paramReader)
         {
             if (command.SetupCommand(cnn, paramReader) is DbCommand dbCommand)
             {
@@ -405,14 +407,14 @@ namespace Dapper
 
         private static async Task<IEnumerable<T>> QueryAsync<T>(this IDbConnection cnn, Type effectiveType, CommandDefinition command)
         {
-            object param = command.Parameters;
+            object? param = command.Parameters;
             var identity = new Identity(command.CommandText, command.CommandType, cnn, effectiveType, param?.GetType());
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
             var cancel = command.CancellationToken;
             using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
             {
-                DbDataReader reader = null;
+                DbDataReader? reader = null;
                 try
                 {
                     if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
@@ -436,10 +438,10 @@ namespace Dapper
                         var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
                         while (await reader.ReadAsync(cancel).ConfigureAwait(false))
                         {
-                            object val = func(reader);
+                            object? val = func(reader);
                             if (val == null || val is T)
                             {
-                                buffer.Add((T)val);
+                                buffer.Add((T)val!);
                             }
                             else
                             {
@@ -469,14 +471,14 @@ namespace Dapper
 
         private static async Task<T> QueryRowAsync<T>(this IDbConnection cnn, Row row, Type effectiveType, CommandDefinition command)
         {
-            object param = command.Parameters;
+            object? param = command.Parameters;
             var identity = new Identity(command.CommandText, command.CommandType, cnn, effectiveType, param?.GetType());
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
             var cancel = command.CancellationToken;
             using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
             {
-                DbDataReader reader = null;
+                DbDataReader? reader = null;
                 try
                 {
                     if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
@@ -484,7 +486,7 @@ namespace Dapper
                     ? CommandBehavior.SequentialAccess | CommandBehavior.SingleResult // need to allow multiple rows, to check fail condition
                     : CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow, cancel).ConfigureAwait(false);
 
-                    T result = default(T);
+                    T result = default!;
                     if (await reader.ReadAsync(cancel).ConfigureAwait(false) && reader.FieldCount != 0)
                     {
                         var tuple = info.Deserializer;
@@ -500,7 +502,7 @@ namespace Dapper
                         object val = func(reader);
                         if (val == null || val is T)
                         {
-                            result = (T)val;
+                            result = (T)val!;
                         }
                         else
                         {
@@ -535,7 +537,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>The number of rows affected.</returns>
-        public static Task<int> ExecuteAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<int> ExecuteAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             ExecuteAsync(cnn, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default(CancellationToken)));
 
         /// <summary>
@@ -546,8 +548,8 @@ namespace Dapper
         /// <returns>The number of rows affected.</returns>
         public static Task<int> ExecuteAsync(this IDbConnection cnn, CommandDefinition command)
         {
-            object param = command.Parameters;
-            IEnumerable multiExec = GetMultiExec(param);
+            object? param = command.Parameters;
+            IEnumerable? multiExec = GetMultiExec(param);
             if (multiExec != null)
             {
                 return ExecuteMultiImplAsync(cnn, command, multiExec);
@@ -578,13 +580,13 @@ namespace Dapper
             {
                 if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
 
-                CacheInfo info = null;
-                string masterSql = null;
+                CacheInfo? info = null;
+                string? masterSql = null;
                 if ((command.Flags & CommandFlags.Pipelined) != 0)
                 {
                     const int MAX_PENDING = 100;
                     var pending = new Queue<AsyncExecState>(MAX_PENDING);
-                    DbCommand cmd = null;
+                    DbCommand? cmd = null;
                     try
                     {
                         foreach (var obj in multiExec)
@@ -594,6 +596,9 @@ namespace Dapper
                                 isFirst = false;
                                 cmd = command.TrySetupAsyncCommand(cnn, null);
                                 masterSql = cmd.CommandText;
+
+                                if (obj is null) throw new ArgumentException("The first item in multiExec must not be null.", nameof(multiExec));
+
                                 var identity = new Identity(command.CommandText, cmd.CommandType, cnn, null, obj.GetType());
                                 info = GetCacheInfo(identity, obj, command.AddToCache);
                             }
@@ -609,7 +614,7 @@ namespace Dapper
                             {
                                 cmd = command.TrySetupAsyncCommand(cnn, null);
                             }
-                            info.ParamReader(cmd, obj);
+                            info!.ParamReader(cmd, obj);
 
                             var task = cmd.ExecuteNonQueryAsync(command.CancellationToken);
                             pending.Enqueue(new AsyncExecState(cmd, task));
@@ -642,6 +647,8 @@ namespace Dapper
                             {
                                 masterSql = cmd.CommandText;
                                 isFirst = false;
+                                if (obj is null) throw new ArgumentException("The first item in multiExec must not be null.", nameof(multiExec));
+
                                 var identity = new Identity(command.CommandText, cmd.CommandType, cnn, null, obj.GetType());
                                 info = GetCacheInfo(identity, obj, command.AddToCache);
                             }
@@ -650,7 +657,7 @@ namespace Dapper
                                 cmd.CommandText = masterSql; // because we do magic replaces on "in" etc
                                 cmd.Parameters.Clear(); // current code is Add-tastic
                             }
-                            info.ParamReader(cmd, obj);
+                            info!.ParamReader(cmd, obj);
                             total += await cmd.ExecuteNonQueryAsync(command.CancellationToken).ConfigureAwait(false);
                         }
                     }
@@ -665,7 +672,7 @@ namespace Dapper
             return total;
         }
 
-        private static async Task<int> ExecuteImplAsync(IDbConnection cnn, CommandDefinition command, object param)
+        private static async Task<int> ExecuteImplAsync(IDbConnection cnn, CommandDefinition command, object? param)
         {
             var identity = new Identity(command.CommandText, command.CommandType, cnn, null, param?.GetType());
             var info = GetCacheInfo(identity, param, command.AddToCache);
@@ -703,7 +710,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TReturn> map, object? param = null, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn,
                 new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
 
@@ -740,7 +747,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TReturn> map, object? param = null, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn,
                 new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
 
@@ -779,7 +786,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, object? param = null, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, TFourth, DontMap, DontMap, DontMap, TReturn>(cnn,
                 new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
 
@@ -820,7 +827,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, object? param = null, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, TFourth, TFifth, DontMap, DontMap, TReturn>(cnn,
                 new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
 
@@ -863,7 +870,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, object? param = null, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, DontMap, TReturn>(cnn,
                 new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
 
@@ -908,7 +915,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, object? param = null, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(cnn,
                 new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
 
@@ -934,7 +941,7 @@ namespace Dapper
 
         private static async Task<IEnumerable<TReturn>> MultiMapAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, CommandDefinition command, Delegate map, string splitOn)
         {
-            object param = command.Parameters;
+            object? param = command.Parameters;
             var identity = new Identity<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(command.CommandText, command.CommandType, cnn, typeof(TFirst), param?.GetType());
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
@@ -971,20 +978,20 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDbConnection cnn, string sql, Type[] types, Func<object[], TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDbConnection cnn, string sql, Type[] types, Func<object?[], TReturn> map, object? param = null, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken));
             return MultiMapAsync(cnn, command, types, map, splitOn);
         }
 
-        private static async Task<IEnumerable<TReturn>> MultiMapAsync<TReturn>(this IDbConnection cnn, CommandDefinition command, Type[] types, Func<object[], TReturn> map, string splitOn)
+        private static async Task<IEnumerable<TReturn>> MultiMapAsync<TReturn>(this IDbConnection cnn, CommandDefinition command, Type[] types, Func<object?[], TReturn> map, string splitOn)
         {
             if (types.Length < 1)
             {
                 throw new ArgumentException("you must provide at least one type to deserialize");
             }
 
-            object param = command.Parameters;
+            object? param = command.Parameters;
             var identity = new IdentityWithTypes(command.CommandText, command.CommandType, cnn, types[0], param?.GetType(), types);
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
@@ -1004,7 +1011,7 @@ namespace Dapper
             }
         }
 
-        private static IEnumerable<T> ExecuteReaderSync<T>(IDataReader reader, Func<IDataReader, object> func, object parameters)
+        private static IEnumerable<T> ExecuteReaderSync<T>(IDataReader reader, Func<IDataReader, object> func, object? parameters)
         {
             using (reader)
             {
@@ -1026,7 +1033,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
-        public static Task<GridReader> QueryMultipleAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<GridReader> QueryMultipleAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             QueryMultipleAsync(cnn, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered));
 
         /// <summary>
@@ -1036,12 +1043,12 @@ namespace Dapper
         /// <param name="command">The command to execute for this query.</param>
         public static async Task<GridReader> QueryMultipleAsync(this IDbConnection cnn, CommandDefinition command)
         {
-            object param = command.Parameters;
+            object? param = command.Parameters;
             var identity = new Identity(command.CommandText, command.CommandType, cnn, typeof(GridReader), param?.GetType());
             CacheInfo info = GetCacheInfo(identity, param, command.AddToCache);
 
-            DbCommand cmd = null;
-            IDataReader reader = null;
+            DbCommand? cmd = null;
+            IDataReader? reader = null;
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
@@ -1062,7 +1069,7 @@ namespace Dapper
                 {
                     if (!reader.IsClosed)
                     {
-                        try { cmd.Cancel(); }
+                        try { cmd!.Cancel(); }
                         catch
                         { /* don't spoil the existing exception */
                         }
@@ -1100,7 +1107,7 @@ namespace Dapper
         /// ]]>
         /// </code>
         /// </example>
-        public static Task<IDataReader> ExecuteReaderAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<IDataReader> ExecuteReaderAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             ExecuteWrappedReaderImplAsync(cnn, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered), CommandBehavior.Default).CastResult<DbDataReader, IDataReader>();
 
         /// <summary>
@@ -1112,7 +1119,7 @@ namespace Dapper
         /// <param name="transaction">The transaction to use for this command.</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
-        public static Task<DbDataReader> ExecuteReaderAsync(this DbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<DbDataReader> ExecuteReaderAsync(this DbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             ExecuteWrappedReaderImplAsync(cnn, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered), CommandBehavior.Default);
 
         /// <summary>
@@ -1161,9 +1168,9 @@ namespace Dapper
 
         private static async Task<DbDataReader> ExecuteWrappedReaderImplAsync(IDbConnection cnn, CommandDefinition command, CommandBehavior commandBehavior)
         {
-            Action<IDbCommand, object> paramReader = GetParameterReader(cnn, ref command);
+            Action<IDbCommand, object?>? paramReader = GetParameterReader(cnn, ref command);
 
-            DbCommand cmd = null;
+            DbCommand? cmd = null;
             bool wasClosed = cnn.State == ConnectionState.Closed, disposeCommand = true;
             try
             {
@@ -1191,7 +1198,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>The first cell returned, as <see cref="object"/>.</returns>
-        public static Task<object> ExecuteScalarAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<object> ExecuteScalarAsync(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             ExecuteScalarImplAsync<object>(cnn, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered));
 
         /// <summary>
@@ -1205,7 +1212,7 @@ namespace Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>The first cell returned, as <typeparamref name="T"/>.</returns>
-        public static Task<T> ExecuteScalarAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+        public static Task<T> ExecuteScalarAsync<T>(this IDbConnection cnn, string sql, object? param = null, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
             ExecuteScalarImplAsync<T>(cnn, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered));
 
         /// <summary>
@@ -1229,15 +1236,15 @@ namespace Dapper
 
         private static async Task<T> ExecuteScalarImplAsync<T>(IDbConnection cnn, CommandDefinition command)
         {
-            Action<IDbCommand, object> paramReader = null;
-            object param = command.Parameters;
+            Action<IDbCommand, object?>? paramReader = null;
+            object? param = command.Parameters;
             if (param != null)
             {
                 var identity = new Identity(command.CommandText, command.CommandType, cnn, null, param.GetType());
                 paramReader = GetCacheInfo(identity, command.Parameters, command.AddToCache).ParamReader;
             }
 
-            DbCommand cmd = null;
+            DbCommand? cmd = null;
             bool wasClosed = cnn.State == ConnectionState.Closed;
             object result;
             try

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -368,7 +368,7 @@ namespace Dapper
         private static Task<DbDataReader> ExecuteReaderWithFlagsFallbackAsync(DbCommand cmd, bool wasClosed, CommandBehavior behavior, CancellationToken cancellationToken)
         {
             var task = cmd.ExecuteReaderAsync(GetBehavior(wasClosed, behavior), cancellationToken);
-            if (task.Status == TaskStatus.Faulted && Settings.DisableCommandBehaviorOptimizations(behavior, task.Exception!.InnerException))
+            if (task.Exception?.InnerException is { } ex && Settings.DisableCommandBehaviorOptimizations(behavior, ex))
             { // we can retry; this time it will have different flags
                 return cmd.ExecuteReaderAsync(GetBehavior(wasClosed, behavior), cancellationToken);
             }

--- a/Dapper/SqlMapper.ICustomQueryParameter.cs
+++ b/Dapper/SqlMapper.ICustomQueryParameter.cs
@@ -1,5 +1,7 @@
 ﻿using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper

--- a/Dapper/SqlMapper.IDataReader.cs
+++ b/Dapper/SqlMapper.IDataReader.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -20,10 +22,10 @@ namespace Dapper
                 var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
                 do
                 {
-                    object val = deser(reader);
+                    object? val = deser(reader);
                     if (val == null || val is T)
                     {
-                        yield return (T)val;
+                        yield return (T)val!;
                     }
                     else
                     {
@@ -38,7 +40,7 @@ namespace Dapper
         /// </summary>
         /// <param name="reader">The data reader to parse results from.</param>
         /// <param name="type">The type to parse from the <paramref name="reader"/>.</param>
-        public static IEnumerable<object> Parse(this IDataReader reader, Type type)
+        public static IEnumerable<object?> Parse(this IDataReader reader, Type type)
         {
             if (reader.Read())
             {
@@ -54,7 +56,7 @@ namespace Dapper
         /// Parses a data reader to a sequence of dynamic. Used for deserializing a reader without a connection, etc.
         /// </summary>
         /// <param name="reader">The data reader to parse results from.</param>
-        public static IEnumerable<dynamic> Parse(this IDataReader reader)
+        public static IEnumerable<dynamic?> Parse(this IDataReader reader)
         {
             if (reader.Read())
             {
@@ -76,7 +78,7 @@ namespace Dapper
         /// <param name="length">The length of columns to read (default -1 = all fields following startIndex)</param>
         /// <param name="returnNullIfFirstMissing">Return null if we can't find the first column? (default false)</param>
         /// <returns>A parser for this specific object from this row.</returns>
-        public static Func<IDataReader, object> GetRowParser(this IDataReader reader, Type type,
+        public static Func<IDataReader, object?> GetRowParser(this IDataReader reader, Type type,
             int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
         {
             return GetDeserializer(type, reader, startIndex, length, returnNullIfFirstMissing);
@@ -135,14 +137,14 @@ namespace Dapper
         ///     public override int Type =&gt; 2;
         /// }
         /// </example>
-        public static Func<IDataReader, T> GetRowParser<T>(this IDataReader reader, Type concreteType = null,
+        public static Func<IDataReader, T> GetRowParser<T>(this IDataReader reader, Type? concreteType = null,
             int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
         {
             concreteType = concreteType ?? typeof(T);
             var func = GetDeserializer(concreteType, reader, startIndex, length, returnNullIfFirstMissing);
             if (concreteType.IsValueType)
             {
-                return _ => (T)func(_);
+                return _ => (T)func(_)!;
             }
             else
             {

--- a/Dapper/SqlMapper.IDynamicParameters.cs
+++ b/Dapper/SqlMapper.IDynamicParameters.cs
@@ -1,5 +1,7 @@
 ﻿using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper

--- a/Dapper/SqlMapper.IMemberMap.cs
+++ b/Dapper/SqlMapper.IMemberMap.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Reflection;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -23,17 +25,17 @@ namespace Dapper
             /// <summary>
             /// Target property
             /// </summary>
-            PropertyInfo Property { get; }
+            PropertyInfo? Property { get; }
 
             /// <summary>
             /// Target field
             /// </summary>
-            FieldInfo Field { get; }
+            FieldInfo? Field { get; }
 
             /// <summary>
             /// Target constructor parameter
             /// </summary>
-            ParameterInfo Parameter { get; }
+            ParameterInfo? Parameter { get; }
         }
     }
 }

--- a/Dapper/SqlMapper.IParameterCallbacks.cs
+++ b/Dapper/SqlMapper.IParameterCallbacks.cs
@@ -1,4 +1,6 @@
-﻿namespace Dapper
+﻿#nullable enable
+
+namespace Dapper
 {
     public static partial class SqlMapper
     {

--- a/Dapper/SqlMapper.IParameterLookup.cs
+++ b/Dapper/SqlMapper.IParameterLookup.cs
@@ -1,4 +1,6 @@
-﻿namespace Dapper
+﻿#nullable enable
+
+namespace Dapper
 {
     public static partial class SqlMapper
     {
@@ -11,7 +13,7 @@
             /// Get the value of the specified parameter (return null if not found)
             /// </summary>
             /// <param name="name">The name of the parameter to get.</param>
-            object this[string name] { get; }
+            object? this[string name] { get; }
         }
     }
 }

--- a/Dapper/SqlMapper.ITypeHandler.cs
+++ b/Dapper/SqlMapper.ITypeHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -15,7 +17,7 @@ namespace Dapper
             /// </summary>
             /// <param name="parameter">The parameter to configure</param>
             /// <param name="value">Parameter value</param>
-            void SetValue(IDbDataParameter parameter, object value);
+            void SetValue(IDbDataParameter parameter, object? value);
 
             /// <summary>
             /// Parse a database value back to a typed value
@@ -23,7 +25,7 @@ namespace Dapper
             /// <param name="value">The value from the database</param>
             /// <param name="destinationType">The type to parse to</param>
             /// <returns>The typed value</returns>
-            object Parse(Type destinationType, object value);
+            object? Parse(Type destinationType, object? value);
         }
     }
 }

--- a/Dapper/SqlMapper.ITypeMap.cs
+++ b/Dapper/SqlMapper.ITypeMap.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Reflection;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -16,7 +18,7 @@ namespace Dapper
             /// <param name="names">DataReader column names</param>
             /// <param name="types">DataReader column types</param>
             /// <returns>Matching constructor or default one</returns>
-            ConstructorInfo FindConstructor(string[] names, Type[] types);
+            ConstructorInfo? FindConstructor(string[] names, Type[] types);
 
             /// <summary>
             /// Returns a constructor which should *always* be used.
@@ -25,7 +27,7 @@ namespace Dapper
             /// 
             /// Use this class to force object creation away from parameterless constructors you don't control.
             /// </summary>
-            ConstructorInfo FindExplicitConstructor();
+            ConstructorInfo? FindExplicitConstructor();
 
             /// <summary>
             /// Gets mapping for constructor parameter
@@ -40,7 +42,7 @@ namespace Dapper
             /// </summary>
             /// <param name="columnName">DataReader column name</param>
             /// <returns>Mapping implementation</returns>
-            IMemberMap GetMember(string columnName);
+            IMemberMap? GetMember(string columnName);
         }
     }
 }

--- a/Dapper/SqlMapper.Link.cs
+++ b/Dapper/SqlMapper.Link.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+#nullable enable
 
 namespace Dapper
 {
@@ -11,24 +14,24 @@ namespace Dapper
         /// </summary>
         /// <typeparam name="TKey">The type to cache.</typeparam>
         /// <typeparam name="TValue">The value type of the cache.</typeparam>
-        internal class Link<TKey, TValue> where TKey : class
+        internal class Link<TKey, TValue> where TKey : class?
         {
-            public static bool TryGet(Link<TKey, TValue> link, TKey key, out TValue value)
+            public static bool TryGet(Link<TKey, TValue>? link, TKey key, [MaybeNullWhen(false)] out TValue value)
             {
                 while (link != null)
                 {
-                    if ((object)key == (object)link.Key)
+                    if (key == link.Key)
                     {
                         value = link.Value;
                         return true;
                     }
                     link = link.Tail;
                 }
-                value = default(TValue);
+                value = default!;
                 return false;
             }
 
-            public static bool TryAdd(ref Link<TKey, TValue> head, TKey key, ref TValue value)
+            public static bool TryAdd([NotNull] ref Link<TKey, TValue>? head, TKey key, ref TValue value)
             {
                 bool tryAgain;
                 do
@@ -46,7 +49,7 @@ namespace Dapper
                 return true;
             }
 
-            private Link(TKey key, TValue value, Link<TKey, TValue> tail)
+            private Link(TKey key, TValue value, Link<TKey, TValue>? tail)
             {
                 Key = key;
                 Value = value;
@@ -55,7 +58,7 @@ namespace Dapper
 
             public TKey Key { get; }
             public TValue Value { get; }
-            public Link<TKey, TValue> Tail { get; }
+            public Link<TKey, TValue>? Tail { get; }
         }
     }
 }

--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper

--- a/Dapper/SqlMapper.TypeHandler.cs
+++ b/Dapper/SqlMapper.TypeHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -23,9 +25,9 @@ namespace Dapper
             /// </summary>
             /// <param name="value">The value from the database</param>
             /// <returns>The typed value</returns>
-            public abstract T Parse(object value);
+            public abstract T Parse(object? value);
 
-            void ITypeHandler.SetValue(IDbDataParameter parameter, object value)
+            void ITypeHandler.SetValue(IDbDataParameter parameter, object? value)
             {
                 if (value is DBNull)
                 {
@@ -33,11 +35,11 @@ namespace Dapper
                 }
                 else
                 {
-                    SetValue(parameter, (T)value);
+                    SetValue(parameter, (T)value!);
                 }
             }
 
-            object ITypeHandler.Parse(Type destinationType, object value)
+            object? ITypeHandler.Parse(Type destinationType, object? value)
             {
                 return Parse(value);
             }
@@ -76,9 +78,9 @@ namespace Dapper
             /// </summary>
             /// <param name="value">The value from the database</param>
             /// <returns>The typed value</returns>
-            public override T Parse(object value)
+            public override T Parse(object? value)
             {
-                if (value == null || value is DBNull) return default(T);
+                if (value == null || value is DBNull) return default!;
                 return Parse((string)value);
             }
         }

--- a/Dapper/SqlMapper.TypeHandlerCache.cs
+++ b/Dapper/SqlMapper.TypeHandlerCache.cs
@@ -2,6 +2,8 @@
 using System.ComponentModel;
 using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -20,7 +22,7 @@ namespace Dapper
             /// </summary>
             /// <param name="value">The object to parse.</param>
             [Obsolete(ObsoleteInternalUsageOnly, true)]
-            public static T Parse(object value) => (T)handler.Parse(typeof(T), value);
+            public static T Parse(object? value) => (T)handler!.Parse(typeof(T), value)!;
 
             /// <summary>
             /// Not intended for direct usage.
@@ -28,7 +30,7 @@ namespace Dapper
             /// <param name="parameter">The parameter to set a value for.</param>
             /// <param name="value">The value to set.</param>
             [Obsolete(ObsoleteInternalUsageOnly, true)]
-            public static void SetValue(IDbDataParameter parameter, object value) => handler.SetValue(parameter, value);
+            public static void SetValue(IDbDataParameter parameter, object? value) => handler!.SetValue(parameter, value);
 
             internal static void SetHandler(ITypeHandler handler)
             {
@@ -37,7 +39,7 @@ namespace Dapper
 #pragma warning restore 618
             }
 
-            private static ITypeHandler handler;
+            private static ITypeHandler? handler;
         }
     }
 }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1966,7 +1966,7 @@ namespace Dapper
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete(ObsoleteInternalUsageOnly, false)]
-        public static void PackListParameters(IDbCommand command, string namePrefix, object value)
+        public static void PackListParameters(IDbCommand command, string namePrefix, object? value)
         {
             // initially we tried TVP, however it performs quite poorly.
             // keep in mind SQL support up to 2000 params easily in sp_executesql, needing more is rare

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -527,7 +527,6 @@ namespace Dapper
                     // this includes all the code for concurrent/overlapped query
                     return ExecuteMultiImplAsync(cnn, command, multiExec).Result;
                 }
-                bool isFirst = true;
                 int total = 0;
                 bool wasClosed = cnn.State == ConnectionState.Closed;
                 try
@@ -538,10 +537,9 @@ namespace Dapper
                         string? masterSql = null;
                         foreach (var obj in multiExec)
                         {
-                            if (isFirst)
+                            if (info is null)
                             {
                                 masterSql = cmd.CommandText;
-                                isFirst = false;
 
                                 if (obj is null) throw new ArgumentException("The first item in multiExec must not be null.", nameof(multiExec));
 
@@ -2298,13 +2296,11 @@ namespace Dapper
                         if (multiExec != null)
                         {
                             StringBuilder? sb = null;
-                            bool first = true;
                             foreach (object? subval in multiExec)
                             {
-                                if (first)
+                                if (sb is null)
                                 {
                                     sb = GetStringBuilder().Append('(');
-                                    first = false;
                                 }
                                 else
                                 {
@@ -2312,7 +2308,7 @@ namespace Dapper
                                 }
                                 sb.Append(Format(subval));
                             }
-                            if (first)
+                            if (sb is null)
                             {
                                 return "(select null where 1=0)";
                             }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2327,7 +2327,7 @@ namespace Dapper
             var sql = command.CommandText;
             foreach (var token in tokens)
             {
-                object value = parameters[token.Member];
+                object? value = parameters[token.Member];
 #pragma warning disable 0618
                 string text = Format(value);
 #pragma warning restore 0618
@@ -2941,7 +2941,7 @@ namespace Dapper
             }
             if (typeHandlers.TryGetValue(type, out ITypeHandler? handler))
             {
-                return (T)handler.Parse(type, value);
+                return (T)handler.Parse(type, value)!;
             }
             return (T)Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
         }
@@ -3297,7 +3297,7 @@ namespace Dapper
                         }
                         else
                         {
-                            il.Emit(OpCodes.Stfld, item.Field); // stack is now [target]
+                            il.Emit(OpCodes.Stfld, item.Field!); // stack is now [target]
                         }
                     }
 
@@ -3330,7 +3330,7 @@ namespace Dapper
                         }
                         else
                         {
-                            il.Emit(OpCodes.Stfld, item.Field); // stack is now [target]
+                            il.Emit(OpCodes.Stfld, item.Field!); // stack is now [target]
                         }
                     }
                     else

--- a/Dapper/TableValuedParameter.cs
+++ b/Dapper/TableValuedParameter.cs
@@ -1,5 +1,7 @@
 ﻿using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     /// <summary>
@@ -8,7 +10,7 @@ namespace Dapper
     internal sealed class TableValuedParameter : SqlMapper.ICustomQueryParameter
     {
         private readonly DataTable table;
-        private readonly string typeName;
+        private readonly string? typeName;
 
         /// <summary>
         /// Create a new instance of <see cref="TableValuedParameter"/>.
@@ -21,7 +23,7 @@ namespace Dapper
         /// </summary>
         /// <param name="table">The <see cref="DataTable"/> to create this parameter for.</param>
         /// <param name="typeName">The name of the type this parameter is for.</param>
-        public TableValuedParameter(DataTable table, string typeName)
+        public TableValuedParameter(DataTable table, string? typeName)
         {
             this.table = table;
             this.typeName = typeName;
@@ -35,7 +37,7 @@ namespace Dapper
             command.Parameters.Add(param);
         }
 
-        internal static void Set(IDbDataParameter parameter, DataTable table, string typeName)
+        internal static void Set(IDbDataParameter parameter, DataTable? table, string? typeName)
         {
 #pragma warning disable 0618
             parameter.Value = SqlMapper.SanitizeParameterValue(table);

--- a/Dapper/TypeExtensions.cs
+++ b/Dapper/TypeExtensions.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Reflection;
 
+#nullable enable
+
 namespace Dapper
 {
     internal static class TypeExtensions
     {
-        public static MethodInfo GetPublicInstanceMethod(this Type type, string name, Type[] types)
+        public static MethodInfo? GetPublicInstanceMethod(this Type type, string name, Type[] types)
             => type.GetMethod(name, BindingFlags.Instance | BindingFlags.Public, null, types, null);
     }
 }

--- a/Dapper/UdtTypeHandler.cs
+++ b/Dapper/UdtTypeHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -22,12 +24,12 @@ namespace Dapper
                 this.udtTypeName = udtTypeName;
             }
 
-            object ITypeHandler.Parse(Type destinationType, object value)
+            object? ITypeHandler.Parse(Type destinationType, object? value)
             {
                 return value is DBNull ? null : value;
             }
 
-            void ITypeHandler.SetValue(IDbDataParameter parameter, object value)
+            void ITypeHandler.SetValue(IDbDataParameter parameter, object? value)
             {
 #pragma warning disable 0618
                 parameter.Value = SanitizeParameterValue(value);

--- a/Dapper/WrappedDataReader.cs
+++ b/Dapper/WrappedDataReader.cs
@@ -1,5 +1,7 @@
 ﻿using System.Data;
 
+#nullable enable
+
 namespace Dapper
 {
     /// <summary>

--- a/Dapper/XmlHandlers.cs
+++ b/Dapper/XmlHandlers.cs
@@ -2,6 +2,8 @@
 using System.Xml;
 using System.Xml.Linq;
 
+#nullable enable
+
 namespace Dapper
 {
     internal abstract class XmlTypeHandler<T> : SqlMapper.StringTypeHandler<T>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Copyright>2019 Stack Exchange, Inc.</Copyright>
 
+    <LangVersion>8</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../Dapper.snk</AssemblyOriginatorKeyFile>
@@ -13,7 +14,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StackExchange/Dapper</RepositoryUrl>
     <Deterministic>false</Deterministic>
-    
+
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <DefaultLanguage>en-US</DefaultLanguage>
@@ -22,9 +23,17 @@
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.26" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <AnnotatedReferenceAssemblyVersion>3.1.0</AnnotatedReferenceAssemblyVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.138" PrivateAssets="all" />
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I didn't enable NRTs everywhere, just enough to get the whole public surface annotated.

More work can be incrementally done by adding `#nullable enable` to remaining files and fixing warnings. Once all files in a project have `#nullable enable`, the preprocessor can be replaced with `<Nullable>enable</Nullable>` in the csproj.

/cc @mgravell 