### PR TITLE
SqlBuilder Support Update Set

### DIFF
--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -151,7 +151,7 @@ namespace Dapper
             AddClause("having", sql, parameters, "\nAND ", "HAVING ", "\n", false);
 
         public SqlBuilder Set(string sql, dynamic parameters = null) =>
-             AddClause("set", sql, parameters, " , ", "SET", "\n", false);
+             AddClause("set", sql, parameters, " , ", "SET ", "\n", false);
 
     }
 }

--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -151,6 +151,7 @@ namespace Dapper
             AddClause("having", sql, parameters, "\nAND ", "HAVING ", "\n", false);
 
         public SqlBuilder Set(string sql, dynamic parameters = null) =>
-             AddClause("set", sql, parameters, " , ", "Set ", "\n", false);
+             AddClause("set", sql, parameters, " , ", "SET", "\n", false);
+
     }
 }

--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -149,5 +149,8 @@ namespace Dapper
 
         public SqlBuilder Having(string sql, dynamic parameters = null) =>
             AddClause("having", sql, parameters, "\nAND ", "HAVING ", "\n", false);
+
+        public SqlBuilder Set(string sql, dynamic parameters = null) =>
+             AddClause("set", sql, parameters, " , ", "Set ", "\n", false);
     }
 }

--- a/Dapper.Tests/SqlBuilderTests.cs
+++ b/Dapper.Tests/SqlBuilderTests.cs
@@ -69,7 +69,8 @@ namespace Dapper.Tests
 
                 var result = connection.QueryFirst("select * from #Users where Id = 1");
 
-                Assert.Equal("update #Users Set vip = @vip , updatetime = @updatetime\n WHERE id = @id\n", template.RawSql);
+                Assert.Equal("update #Users SET vip = @vip , updatetime = @updatetime\n WHERE id = @id\n", template.RawSql);
+
 
                 Assert.True((bool)result.Vip);
                 Assert.Equal(updatetime, (DateTime)result.Updatetime);


### PR DESCRIPTION
I add update `Set` method and unit test.

e.g: 
```C#
var sb = new SqlBuilder()
       .Set("vip = @vip", new { vip })
       .Set("updatetime = @updatetime", new { updatetime })
       .Where("id = @id", new { id })
;
var template = sb.AddTemplate("update #Users /**set**/ /**where**/");
connection.Execute(template.RawSql, template.Parameters);
```

RawSql will generate :　
```
update #Users Set vip = @vip , updatetime = @updatetime\n WHERE id = @id\n
```

using Dapper Execute in sqlserver it'll reqeust by below sql command
```
exec sp_executesql N'update #Users Set vip = @vip , updatetime = @updatetime
 WHERE id = @id
',N'@vip bit,@updatetime datetime,@id int',@vip=1,@updatetime='2020-01-01 00:00:00',@id=1
```