### PR TITLE
add Dapper.EntityFrameworkCore for NetTopologySuite handler

### DIFF
--- a/Dapper.EntityFrameworkCore/Dapper.EntityFrameworkCore.csproj
+++ b/Dapper.EntityFrameworkCore/Dapper.EntityFrameworkCore.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Dapper.EntityFrameworkCore</AssemblyName>
+    <Description>Extension handlers for entity framework core</Description>
+    <AssemblyTitle>Dapper entity framework core type handlers</AssemblyTitle>
+    <VersionPrefix>1.50.2</VersionPrefix>
+    <Authors>Marc Gravell;Nick Craver</Authors>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageTags>orm;sql;micro-orm</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NetTopologySuite" Version="2.0.0" />
+    <PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dapper\Dapper.csproj" />
+    <!-- note: 6.2.0 has regressions; don't force the update -->
+  </ItemGroup>
+</Project>

--- a/Dapper.EntityFrameworkCore/Handlers.cs
+++ b/Dapper.EntityFrameworkCore/Handlers.cs
@@ -1,0 +1,40 @@
+﻿using NetTopologySuite.Geometries;
+
+namespace Dapper.EntityFrameworkCore
+{
+    /// <summary>
+    /// Acts on behalf of all type-handlers in this package
+    /// </summary>
+    public static class Handlers
+    {
+        /// <summary>
+        /// Register geography type-handlers in this package
+        /// </summary>
+        public static void RegisterGeography()
+        {
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<Point>(true));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<Polygon>(true));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<LineString>(true));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<LinearRing>(true));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<MultiLineString>(true));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<MultiPoint>(true));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<MultiPolygon>(true));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<Geometry>(true));
+        }
+
+        /// <summary>
+        /// Register geometry type-handlers in this package
+        /// </summary>
+        public static void RegisterGeometry()
+        {
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<Point>(false));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<Polygon>(false));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<LineString>(false));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<LinearRing>(false));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<MultiLineString>(false));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<MultiPoint>(false));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<MultiPolygon>(false));
+            SqlMapper.AddTypeHandler(new NetTopologySuiteGeometryHandler<Geometry>(false));
+        }
+    }
+}

--- a/Dapper.EntityFrameworkCore/NetTopologySuiteGeometryHandler.cs
+++ b/Dapper.EntityFrameworkCore/NetTopologySuiteGeometryHandler.cs
@@ -1,0 +1,52 @@
+﻿using System.Data;
+using System.Data.SqlClient;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Dapper.EntityFrameworkCore
+{
+    /// <summary>
+    /// Type-handler for the Geometry spatial type.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class NetTopologySuiteGeometryHandler<T> : SqlMapper.TypeHandler<T>
+        where T : Geometry
+    {
+        readonly bool _geography;
+        readonly SqlServerBytesWriter _writer;
+        readonly SqlServerBytesReader _reader;
+
+        /// <summary>
+        /// Create a new handler instance.
+        /// </summary>
+        /// <param name="geography"></param>
+        public NetTopologySuiteGeometryHandler(bool geography = false)
+        {
+            _geography = geography;
+            _writer = new SqlServerBytesWriter { IsGeography = geography };
+            _reader = new SqlServerBytesReader { IsGeography = geography };
+        }
+
+        /// <summary>
+        /// Parse a database value back to a typed value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public override T Parse(object value)
+            => (T)_reader.Read((byte[])value);
+
+        /// <summary>
+        /// Assign the value of a parameter before a command executes.
+        /// </summary>
+        /// <param name="parameter"></param>
+        /// <param name="value"></param>
+        public override void SetValue(IDbDataParameter parameter, T value)
+        {
+            parameter.Value = _writer.Write(value);
+
+            ((SqlParameter)parameter).SqlDbType = SqlDbType.Udt;
+            ((SqlParameter)parameter).UdtTypeName = _geography ? "geography" : "geometry";
+        }
+    }
+
+}

--- a/Dapper.sln
+++ b/Dapper.sln
@@ -5,7 +5,6 @@ VisualStudioVersion = 16.0.28917.182
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A34907DF-958A-4E4C-8491-84CF303FD13E}"
 	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
 		appveyor.yml = appveyor.yml
 		build.ps1 = build.ps1
 		Directory.Build.props = Directory.Build.props
@@ -45,6 +44,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Tests.Performance", "Dapper.Tests.Performance\Dapper.Tests.Performance.csproj", "{F017075A-2969-4A8E-8971-26F154EB420F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.ProviderTools", "Dapper.ProviderTools\Dapper.ProviderTools.csproj", "{B06DB435-0C74-4BD3-BC97-52AF7CF9916B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.EntityFrameworkCore", "Dapper.EntityFrameworkCore\Dapper.EntityFrameworkCore.csproj", "{2387F5B6-0F39-41BF-9955-F0766D0F5DED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -96,6 +97,10 @@ Global
 		{B06DB435-0C74-4BD3-BC97-52AF7CF9916B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B06DB435-0C74-4BD3-BC97-52AF7CF9916B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B06DB435-0C74-4BD3-BC97-52AF7CF9916B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2387F5B6-0F39-41BF-9955-F0766D0F5DED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2387F5B6-0F39-41BF-9955-F0766D0F5DED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2387F5B6-0F39-41BF-9955-F0766D0F5DED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2387F5B6-0F39-41BF-9955-F0766D0F5DED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,6 +117,7 @@ Global
 		{39D3EEB6-9C05-4F4A-8C01-7B209742A7EB} = {4E956F6B-6BD8-46F5-BC85-49292FF8F9AB}
 		{F017075A-2969-4A8E-8971-26F154EB420F} = {568BD46C-1C65-4D44-870C-12CD72563262}
 		{B06DB435-0C74-4BD3-BC97-52AF7CF9916B} = {4E956F6B-6BD8-46F5-BC85-49292FF8F9AB}
+		{2387F5B6-0F39-41BF-9955-F0766D0F5DED} = {4E956F6B-6BD8-46F5-BC85-49292FF8F9AB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {928A4226-96F3-409A-8A83-9E7444488710}


### PR DESCRIPTION
EF Core support for spatial data begin from EF Core 2.2 and using NetTopologySuite as spatial data type base

Adding TypeHandler to resolve NetTopologySuite

Base on https://gist.github.com/bricelam/7eca234674c3ca4150872f899af37611

Sample Code: https://gist.github.com/lettucebo/12076a87afdc0c744c25fa9da4e7c86a

> There is a small catch, when selecting spatial data type from SQL Server, have to Serialize the data in the query
> Example: `Feature.Serialize() AS Feature`

Reference: #1366 