### PR TITLE
Updated InListStringSplitCount comment to GTE.

### DIFF
--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -90,7 +90,7 @@ namespace Dapper
             public static bool PadListExpansions { get; set; }
             /// <summary>
             /// If set (non-negative), when performing in-list expansions of integer types ("where id in @ids", etc), switch to a string_split based
-            /// operation if there are more than this many elements. Note that this feautre requires SQL Server 2016 / compatibility level 130 (or above).
+            /// operation if there are this many elements or more. Note that this feautre requires SQL Server 2016 / compatibility level 130 (or above).
             /// </summary>
             public static int InListStringSplitCount { get; set; } = -1;
         }


### PR DESCRIPTION
The comment suggested that more than the number specified in InListStringSplitCount would start to use string_split.  However, it is greater-than-or-equal-to (GTE) the number specified by InListStringSplitCount.