### PR TITLE
Replaced ContainsKey with TryGetValue

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -551,9 +551,9 @@ namespace Dapper.Contrib.Extensions
             var name = GetDatabaseType?.Invoke(connection).ToLower()
                        ?? connection.GetType().Name.ToLower();
 
-            return !AdapterDictionary.ContainsKey(name)
+            return !AdapterDictionary.TryGetValue(name, out var adapter)
                 ? DefaultAdapter
-                : AdapterDictionary[name];
+                : adapter;
         }
 
         private static class ProxyGenerator


### PR DESCRIPTION
Replaced ContainsKey with TryGetValue to improve perfomance. In order to not request to hashtable twice.