### PR TITLE
Add correct feature flag for ClickHouse

### DIFF
--- a/Dapper/FeatureSupport.cs
+++ b/Dapper/FeatureSupport.cs
@@ -10,7 +10,8 @@ namespace Dapper
     {
         private static readonly FeatureSupport
             Default = new FeatureSupport(false),
-            Postgres = new FeatureSupport(true);
+            Postgres = new FeatureSupport(true),
+            ClickHouse = new FeatureSupport(true);
 
         /// <summary>
         /// Gets the feature set based on the passed connection
@@ -20,6 +21,7 @@ namespace Dapper
         {
             string name = connection?.GetType().Name;
             if (string.Equals(name, "npgsqlconnection", StringComparison.OrdinalIgnoreCase)) return Postgres;
+            if (string.Equals(name, "clickhouseconnection", StringComparison.OrdinalIgnoreCase)) return ClickHouse;
             return Default;
         }
 


### PR DESCRIPTION
Properly indicate array support for [ClickHouse](https://clickhouse.tech/) connections, to support Dapper in [ClickHouse.Client](https://github.com/DarkWanderer/ClickHouse.Client). 
Ref: [original issue](https://github.com/DarkWanderer/ClickHouse.Client/issues/6), #1463 