### PR TITLE
Add support for Array return value (i.e.: QueryAsync<int[]>))

### DIFF
--- a/Dapper.Tests/Providers/PostgresqlTests.cs
+++ b/Dapper.Tests/Providers/PostgresqlTests.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using Microsoft.VisualBasic;
 using Xunit;
 
 namespace Dapper.Tests
@@ -74,6 +75,17 @@ namespace Dapper.Tests
                 Assert.Single(r);
                 Assert.Equal('a', r.Single().CharColumn);
                 transaction.Rollback();
+            }
+        }
+
+        [FactPostgresql]
+        public void TestPostgresqlArray()
+        {
+            using (var conn = GetOpenNpgsqlConnection())
+            {
+                var r = conn.Query<int[]>("select array[1,2,3]").ToList();
+                Assert.Single(r);
+                Assert.Equal(new[] { 1, 2, 3 }, r.Single());
             }
         }
 

--- a/Dapper.Tests/Providers/PostgresqlTests.cs
+++ b/Dapper.Tests/Providers/PostgresqlTests.cs
@@ -2,7 +2,6 @@
 using System.Data;
 using System.Data.Common;
 using System.Linq;
-using Microsoft.VisualBasic;
 using Xunit;
 
 namespace Dapper.Tests
@@ -79,7 +78,7 @@ namespace Dapper.Tests
         }
 
         [FactPostgresql]
-        public void TestPostgresqlArray()
+        public void TestPostgresqlSelectArray()
         {
             using (var conn = GetOpenNpgsqlConnection())
             {

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1801,7 +1801,7 @@ namespace Dapper
                 return GetDapperRowDeserializer(reader, startBound, length, returnNullIfFirstMissing);
             }
             Type underlyingType = null;
-            if (!(typeMap.ContainsKey(type) || type.IsEnum || type.FullName == LinqBinary
+            if (!(typeMap.ContainsKey(type) || type.IsEnum || type.IsArray || type.FullName == LinqBinary
                 || (type.IsValueType && (underlyingType = Nullable.GetUnderlyingType(type)) != null && underlyingType.IsEnum)))
             {
                 if (typeHandlers.TryGetValue(type, out ITypeHandler handler))

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1243,6 +1243,14 @@ namespace Dapper
             {
                 return default;
             }
+            else if (val is Array array && typeof(T).IsArray)
+            {
+                var elementType = typeof(T).GetElementType();
+                var result = Array.CreateInstance(elementType, array.Length);
+                for (int i = 0; i < array.Length; i++)
+                    result.SetValue(Convert.ChangeType(array.GetValue(i), elementType, CultureInfo.InvariantCulture), i);
+                return (T)(object)result;
+            }
             else
             {
                 try


### PR DESCRIPTION
This change allows to execute queries which return arrays as first-class values, i.e.: `QueryAsync<byte[]>(sql)`.

If the type was not guessed exactly (i.e.: `int[]` vs `byte[]`), a conversion is performed