### PR TITLE
Updated #636 Dapper.Contrib - Support for composite keys in Get method

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -196,7 +196,7 @@ namespace Dapper.Contrib.Extensions
             Type keyObjectType = keyObject?.GetType();
 
 
-            if (keyProperties.Count == 1 && (keyObjectType == null || keyObjectType.IsValueType))
+            if (keyProperties.Count == 1 && (keyObjectType == null || keyObjectType.IsValueType || keyObjectType.Equals(typeof(string))))
             {
                 dynParms.Add($"@{keyProperties.First().Name}", keyObject);
             }

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -156,9 +156,8 @@ namespace Dapper.Contrib.Extensions
 
         private static string GenerateGetQuery(IDbConnection connection, Type type, List<PropertyInfo> keyProperties)
         {
-            string sql;
             // Generate query
-            if (!GetQueries.TryGetValue(type.TypeHandle, out sql))
+            if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
             {
                 var name = GetTableName(type);
 


### PR DESCRIPTION
I really like what was done in #636, and I thought it would be more likely this could be included if the PR was updated. I look the branch from @renanmt and added updated the files he had zipped #636 to no longer have conflicts and got some more tests to pass.

Original PR follows.
> Hello guys.

> I changed a bit the implementation of the Get method so it can also work with composite keys. I have a few tables with this design and it always annoyed me the fact that Update, Insert and Delete supported them but I had to write custom queries when I wanted to retrieve records from database.

> The method still works the same way it was defined before.

```
var regularKey = connection.Get<RegularKey>(1);
```
> But now also supports operations like this:
```
var keytest11 = connection.Get<KeyTest>(new KeyTest { Id1 = 1, Id2 = 2 });
var keytest12 = connection.Get<KeyTest>(new { id1 = 1, id2 = 2 });
var keytest21 = connection.Get<KeyTest>(new { Id1 = 2, Id2 = 1 });

var singleKey1 = connection.Get<SingleKey>(1);
var singleKey2 = connection.Get<SingleKey>(new { myKey = 2 });
```

> I was also able to optimize Update and Delete methods a bit by using a new method to retrieve all keys.

> For your appreciation and code review.

> Cheers