### PR TITLE
Extension hook for DataReader

### DIFF
--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -69,6 +69,12 @@ namespace Dapper
         public CommandFlags Flags { get; }
 
         /// <summary>
+        /// Extension point for configuring IDataReader.  Should only be used for setting simple configuration properties.
+        /// If set, this extension point is invoked immediately after the reader is created, e.g. before the first Read.
+        /// </summary>
+        public Action<IDataReader> DataReaderSetup { get; }
+
+        /// <summary>
         /// Can async queries be pipelined?
         /// </summary>
         public bool Pipelined => (Flags & CommandFlags.Pipelined) != 0;
@@ -83,10 +89,10 @@ namespace Dapper
         /// <param name="commandType">The <see cref="CommandType"/> for this command.</param>
         /// <param name="flags">The behavior flags for this command.</param>
         /// <param name="cancellationToken">The cancellation token for this command.</param>
+        /// <param name="dataReaderSetup">IDataReader configuration extension point.</param>
         public CommandDefinition(string commandText, object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null,
                                  CommandType? commandType = null, CommandFlags flags = CommandFlags.Buffered
-                                 , CancellationToken cancellationToken = default(CancellationToken)
-            )
+                                 , CancellationToken cancellationToken = default(CancellationToken), Action<IDataReader> dataReaderSetup = null)
         {
             CommandText = commandText;
             Parameters = parameters;
@@ -95,6 +101,7 @@ namespace Dapper
             CommandType = commandType;
             Flags = flags;
             CancellationToken = cancellationToken;
+            DataReaderSetup = dataReaderSetup;
         }
 
         private CommandDefinition(object parameters) : this()


### PR DESCRIPTION
Added an `Action<IDataReader>` property to CommandDefinition, and if set, that action is invoked after ExecuteDataReader is called on the command object.  

This will enable third-party users to access datareader object after creation, and in the Oracle use-case, set FetchSize property, which can have significant impact on performance.  See issue #654 for details.

Intended usage:
```csharp
var result = connection.Query<FooBar>(new CommandDefinition(
                commandText: "SELECT FOO,BAR FROM FOOBAR"
                dataReaderSetup: reader =>
                {
                    if (reader is OracleDataReader oracleReader)
                    {
                        oracleReader.FetchSize = oracleReader.RowSize * 38;
                    }                    
                }));
```

The downside to doing it this way is that the datareader object with all its properties and methods are exposed to api consumer, and any calls to Read() or other methods that move the datareader forward will result in corrupted results returned from Dapper query methods.  However, usage of this should be the callers responsibility.  

By doing it this way, Dapper does not need to know anything about Oracle or other provider specifics.
