### PR TITLE
Remove Unnecessary Linq Query.

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -1001,7 +1001,7 @@ public partial class PostgresAdapter : ISqlAdapter
                 if (!first)
                     sb.Append(", ");
                 first = false;
-                sb.Append(property.Name);
+                AppendColumnName(sb, property.Name);
             }
         }
 

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -490,7 +490,7 @@ namespace Dapper
 
         void SqlMapper.IParameterCallbacks.OnCompleted()
         {
-            foreach (var param in from p in parameters select p.Value)
+            foreach (var param in parameters.Values)
             {
                 param.OutputCallback?.Invoke(param.OutputTarget, this);
             }


### PR DESCRIPTION
Calling `.Values` on a Dictionary will return a `ValueCollection` which we can iterate it. It is effectively the same as mapping every `KeyValuePair<TKey, TValue>` to its value but it is more efficient.