### PR TITLE
New property Settings.RunQueryAsyncMapOnCapturedContext

### DIFF
--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -915,9 +915,9 @@ namespace Dapper
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
-                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(Settings.RunQueryAsyncMapOnCapturedContext);
                 using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
-                using (var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false))
+                using (var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(Settings.RunQueryAsyncMapOnCapturedContext))
                 {
                     if (!command.Buffered) wasClosed = false; // handing back open reader; rely on command-behavior
                     var results = MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, CommandDefinition.ForCallback(command.Parameters), map, splitOn, reader, identity, true);
@@ -965,9 +965,9 @@ namespace Dapper
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
-                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(Settings.RunQueryAsyncMapOnCapturedContext);
                 using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
-                using (var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false))
+                using (var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(Settings.RunQueryAsyncMapOnCapturedContext))
                 {
                     var results = MultiMapImpl(null, default(CommandDefinition), types, map, splitOn, reader, identity, true);
                     return command.Buffered ? results.ToList() : results;

--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -93,6 +93,12 @@ namespace Dapper
             /// operation if there are this many elements or more. Note that this feature requires SQL Server 2016 / compatibility level 130 (or above).
             /// </summary>
             public static int InListStringSplitCount { get; set; } = -1;
+
+            /// <summary>
+            /// Specifies whether <code>Func&lt;&gt; map</code> in <code>QueryAsync()</code> runs on captured context.
+            /// Enabling the setting allows the <code>map</code> to use context where it is needed, e.g. HttpContext in ASP.NET.
+            /// </summary>
+            public static bool RunQueryAsyncMapOnCapturedContext { get; set; } = false;
         }
     }
 }


### PR DESCRIPTION
The property when enabled allows to use captured context by `Func<> map` in `QueryAsync()`, e.g. HttpContext in ASP.NET application.