### PR TITLE
Update GitHubActionsTestLogger

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -15,7 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="../../Dapper/Dapper.csproj" />
     <ProjectReference Include="../../Dapper.Contrib/Dapper.Contrib.csproj" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
Bumped GitHubActionsTestLogger to v1.1.2 as it fixes a few issues related to reporting in async tests.
https://github.com/Tyrrrz/GitHubActionsTestLogger/blob/master/Changelog.md#v112-26-oct-2020

Note: if you need to, you can silence warnings from skipped tests too:

```
dotnet test --logger "GitHubActions;report-warnings=false"
```