### PR TITLE
Contributing fixes to GitHub Actions workflow (+ClickHouse container)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,14 @@
 name: Main Build
 
 on:
-  pull_request:
   push:
-    branches:
-    - main
-    paths:
-    - '*'
-    - '!/docs/*' # Don't run workflow when files are only in the /docs directory
+    branches: [ main ]
+    paths-ignore:
+    - '**/*.md'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+    - '**/*.md'
 
 jobs:
   vm-job:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.x'
+        dotnet-version: '5.0.100'
     - name: Checkout code
       uses: actions/checkout@v1
     - name: .NET Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,10 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: test
+      clickhouse:
+        image: yandex/clickhouse-server:latest
+        ports:
+        - 8123:8123
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -49,6 +53,7 @@ jobs:
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         PostgesConnectionString: Server=localhost;Port=${{ job.services.postgres.ports[5432] }};Database=test;User Id=postgres;Password=postgres;
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
+        ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default
     - name: Dapper.Contrib Tests
       run: dotnet test tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj -c Release --logger GitHubActions /p:CI=true
       env:
@@ -56,5 +61,6 @@ jobs:
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         PostgesConnectionString: Server=localhost;Port=${{ job.services.postgres.ports[5432] }};Database=test;User Id=postgres;Password=postgres;
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
+        ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default
     - name: .NET Lib Pack
       run: dotnet pack Build.csproj --no-build -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,4 +68,4 @@ jobs:
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default
     - name: .NET Lib Pack
-      run: dotnet pack Build.csproj --no-build --framework net5.0 -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
+      run: dotnet pack Build.csproj --no-build -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
         ports:
         - 8123:8123
     steps:
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.x'
     - name: Checkout code
       uses: actions/checkout@v1
     - name: .NET Build
@@ -62,6 +66,6 @@ jobs:
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         PostgesConnectionString: Server=localhost;Port=${{ job.services.postgres.ports[5432] }};Database=test;User Id=postgres;Password=postgres;
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
-        ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default;Database=default
+        ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default
     - name: .NET Lib Pack
       run: dotnet pack Build.csproj --no-build --framework net5.0 -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,6 @@ jobs:
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         PostgesConnectionString: Server=localhost;Port=${{ job.services.postgres.ports[5432] }};Database=test;User Id=postgres;Password=postgres;
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
-        ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default
+        ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default;Database=default
     - name: .NET Lib Pack
       run: dotnet pack Build.csproj --no-build --framework net5.0 -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Dapper Tests
-      run: dotnet test tests/Dapper.Tests/Dapper.Tests.csproj -c Release --logger GitHubActions /p:CI=true
+      run: dotnet test tests/Dapper.Tests/Dapper.Tests.csproj --framework net5.0 -c Release --logger GitHubActions /p:CI=true
       env:
         MySqlConnectionString: Server=localhost;Port=${{ job.services.mysql.ports[3306] }};Uid=root;Pwd=root;Database=test;Allow User Variables=true
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
@@ -56,7 +56,7 @@ jobs:
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default
     - name: Dapper.Contrib Tests
-      run: dotnet test tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj -c Release --logger GitHubActions /p:CI=true
+      run: dotnet test tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj --framework net5.0 -c Release --logger GitHubActions /p:CI=true
       env:
         MySqlConnectionString: Server=localhost;Port=${{ job.services.mysql.ports[3306] }};Uid=root;Pwd=root;Database=test;Allow User Variables=true
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
@@ -64,4 +64,4 @@ jobs:
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         ClickHouseConnectionString: Host=localhost;Port=${{ job.services.clickhouse.ports[8123] }};Username=default
     - name: .NET Lib Pack
-      run: dotnet pack Build.csproj --no-build -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
+      run: dotnet pack Build.csproj --no-build --framework net5.0 -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true


### PR DESCRIPTION
This PR:

- Limits frameworks used in GH Action build to .NET 5.0 (build succeeds now)
- Adds ClickHouse container (for which I want to contribute test later)

See [example](https://github.com/DarkWanderer/Dapper/runs/1542047673?check_suite_focus=true) of successful build