### PR TITLE
Id should not be a Key when we have any ExplicitKey

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -110,7 +110,7 @@ namespace Dapper.Contrib.Extensions
             if (keyProperties.Count == 0)
             {
                 var idProp = allProperties.Find(p => string.Equals(p.Name, "id", StringComparison.CurrentCultureIgnoreCase));
-                if (idProp != null && !idProp.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute))
+                if (idProp != null && !allProperties.Any(p => p.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute)))
                 {
                     keyProperties.Add(idProp);
                 }

--- a/tests/Dapper.Tests.Contrib/TestSuite.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuite.cs
@@ -15,6 +15,7 @@ namespace Dapper.Tests.Contrib
         [ExplicitKey]
         public string ObjectXId { get; set; }
         public string Name { get; set; }
+        public int Id { get; set; }
     }
 
     [Table("ObjectY")]


### PR DESCRIPTION
Id is assumed to be a Key if the object has no Key, (and Id is not an ExplicitKey) 

Instead we need to check for any ExplicitKey. 

The failure case is if you have a column called "ID" and you don't want it be a primary key. 

(yes this is an unusual / not best practice situation, but sometimes you can't control the names of the "attributes" you are requested to add to tables, and the ORM shouldn't have an opinion in this case)