### PR TITLE
Provide QueryAsync for CommandDefinition with an arbitrary number of input types

### DIFF
--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -939,6 +939,22 @@ namespace Dapper
         public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDbConnection cnn, string sql, Type[] types, Func<object[], TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default);
+            return QueryAsync(cnn, command, types, map, splitOn);
+        }
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with an arbitrary number of input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="types">Array of types in the recordset.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
+        public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDbConnection cnn, CommandDefinition command, Type[] types, Func<object[], TReturn> map, string splitOn = "Id")
+        {
             return MultiMapAsync(cnn, command, types, map, splitOn);
         }
 


### PR DESCRIPTION
This PR resolves #1181.

The issue points out that the overload of QueryAsync that supports an arbitrary number of types does not support receiving a CancellationToken. @NickCraver rightly points out that fixes this directly would be a breaking change.

This PR addresses the same problem in a different way, which is a simple non-breaking change, as suggested by @AndreaCuneo. It introduces an additional overload of QueryAsync taking CommandDefinition, as is consistent with other QueryAsync overloads that support CommandDefinition.