### PR TITLE
Supports Types in Descriptor API - to allow GridViews accept value of same Column type which mapped from Database not arbitary values

### DIFF
--- a/Dapper/SqlMapper.DapperRow.Descriptor.cs
+++ b/Dapper/SqlMapper.DapperRow.Descriptor.cs
@@ -63,12 +63,13 @@ namespace Dapper
                 internal static PropertyDescriptorCollection GetProperties(DapperTable table, IDictionary<string,object> row = null)
                 {
                     string[] names = table?.FieldNames;
+                    Type[] types = table?.FieldTypes;
                     if (names == null || names.Length == 0) return PropertyDescriptorCollection.Empty;
                     var arr = new PropertyDescriptor[names.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
                         var type = row != null && row.TryGetValue(names[i], out var value) && value != null
-                            ? value.GetType() : typeof(object);
+                            ? value.GetType() : types[i];
                         arr[i] = new RowBoundPropertyDescriptor(type, names[i], i);
                     }
                     return new PropertyDescriptorCollection(arr, true);

--- a/Dapper/SqlMapper.DapperTable.cs
+++ b/Dapper/SqlMapper.DapperTable.cs
@@ -8,13 +8,16 @@ namespace Dapper
         private sealed class DapperTable
         {
             private string[] fieldNames;
+            private Type[] fieldTypes;
             private readonly Dictionary<string, int> fieldNameLookup;
 
             internal string[] FieldNames => fieldNames;
-
-            public DapperTable(string[] fieldNames)
+            internal Type[] FieldTypes => fieldTypes;
+            
+            public DapperTable(string[] fieldNames, Type[] fieldTypes)
             {
                 this.fieldNames = fieldNames ?? throw new ArgumentNullException(nameof(fieldNames));
+                this.fieldTypes = fieldTypes ?? throw new ArgumentNullException(nameof(fieldTypes));
 
                 fieldNameLookup = new Dictionary<string, int>(fieldNames.Length, StringComparer.Ordinal);
                 // if there are dups, we want the **first** key to be the "winner" - so iterate backwards

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1852,11 +1852,14 @@ namespace Dapper
                     if (table == null)
                     {
                         string[] names = new string[effectiveFieldCount];
+                        Type[] types = new Type[effectiveFieldCount];
+                        
                         for (int i = 0; i < effectiveFieldCount; i++)
                         {
                             names[i] = r.GetName(i + startBound);
+                            types[i] = r.GetFieldType(i + startBound);
                         }
-                        table = new DapperTable(names);
+                        table = new DapperTable(names,types);
                     }
 
                     var values = new object[effectiveFieldCount];


### PR DESCRIPTION
Hello, **_Mark Gravel_** nice to see you good man again !
Am sorry for posting old issue here which doesn't show actually Issues in Github repo.
I forked one. And showing two screenshot [Before, After]

Its all about New Descriptor API you provided from 1 years ago.
I was shown in PR. some few changes to accept actual data-type value inside Grid Cells not arbitrary values.
 
![Before](https://user-images.githubusercontent.com/33269552/105617317-8fd10b80-5e18-11eb-8230-034170d7c7fc.png)
![After](https://user-images.githubusercontent.com/33269552/105617318-9495bf80-5e18-11eb-900a-257c270f59d8.png)

Thanks in advance. Wish you the best
