### PR TITLE
Adding support for composite keys in Dapper.Contrib

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -141,47 +141,108 @@ namespace Dapper.Contrib.Extensions
             return writeAttribute.Write;
         }
 
-        private static PropertyInfo GetSingleKey<T>(string method)
+        private static List<PropertyInfo> GetAllKeys(Type type)
         {
-            var type = typeof(T);
-            var keys = KeyPropertiesCache(type);
-            var explicitKeys = ExplicitKeyPropertiesCache(type);
-            var keyCount = keys.Count + explicitKeys.Count;
-            if (keyCount > 1)
-                throw new DataException($"{method}<T> only supports an entity with a single [Key] or [ExplicitKey] property. [Key] Count: {keys.Count}, [ExplicitKey] Count: {explicitKeys.Count}");
-            if (keyCount == 0)
-                throw new DataException($"{method}<T> only supports an entity with a [Key] or an [ExplicitKey] property");
+            var keyProperties = KeyPropertiesCache(type).ToList();  //added ToList() due to issue #418, must work on a list copy
+            var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
 
-            return keys.Count > 0 ? keys[0] : explicitKeys[0];
+            keyProperties.AddRange(explicitKeyProperties);
+
+            if (!keyProperties.Any())
+                throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");
+
+            return keyProperties;
+        }
+
+        private static string GenerateGetQuery(IDbConnection connection, Type type, List<PropertyInfo> keyProperties)
+        {
+            // Generate query
+            if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
+            {
+                var name = GetTableName(type);
+
+                if (keyProperties.Count == 1)
+                {
+                    var key = keyProperties.First();
+                    sql = $"select * from {name} where {key.Name} = @{key.Name}";
+                }
+                else
+                {
+                    var sb = new StringBuilder();
+                    sb.AppendFormat("select * from {0} where ", name);
+
+                    var adapter = GetFormatter(connection);
+
+                    for (var i = 0; i < keyProperties.Count; i++)
+                    {
+                        var property = keyProperties.ElementAt(i);
+                        adapter.AppendColumnNameEqualsValue(sb, property.Name);  //fix for issue #336
+                        if (i < keyProperties.Count - 1)
+                            sb.AppendFormat(" and ");
+                    }
+
+                    sql = sb.ToString();
+                }
+
+                GetQueries[type.TypeHandle] = sql;
+            }
+
+            return sql;
+        }
+
+        private static DynamicParameters GenerateGetParams(Type type, dynamic keyObject, List<PropertyInfo> keyProperties)
+        {
+            var dynParms = new DynamicParameters();
+            Type keyObjectType = keyObject?.GetType();
+
+
+            if (keyProperties.Count == 1 && (keyObjectType == null || keyObjectType.IsValueType || keyObjectType.Equals(typeof(string))))
+            {
+                dynParms.Add($"@{keyProperties.First().Name}", keyObject);
+            }
+            else
+            {
+                if (keyObjectType == null || keyObjectType.IsValueType)
+                    throw new ArgumentException($"They key object passed cannot be null or value type for composite key in {type.Name}");
+
+                var isParamSameType = keyObjectType.Equals(type);
+                var keyTypeProperties = isParamSameType ? null : keyObjectType.GetProperties();
+
+                for (var i = 0; i < keyProperties.Count; i++)
+                {
+                    var property = keyProperties.ElementAt(i);
+
+                    var paramProperty = isParamSameType ? property : // if key object passed is the same type as expected result, use property
+                        keyTypeProperties.FirstOrDefault(p => p.Name.Equals(property.Name, StringComparison.CurrentCultureIgnoreCase));
+
+                    if (paramProperty == null)
+                        throw new ArgumentException($"The key object passed does not contain {property.Name} property.");
+
+                    dynParms.Add($"@{property.Name}", paramProperty.GetValue(keyObject, null));
+                }
+            }
+
+            return dynParms;
         }
 
         /// <summary>
-        /// Returns a single entity by a single id from table "Ts".  
-        /// Id must be marked with [Key] attribute.
+        /// Returns a single entity by a key from table "Ts".  
+        /// Keys must be marked with [Key] or [ExplicitKey] attributes.
         /// Entities created from interfaces are tracked/intercepted for changes and used by the Update() extension
         /// for optimal performance. 
         /// </summary>
         /// <typeparam name="T">Interface or type to create and populate</typeparam>
         /// <param name="connection">Open SqlConnection</param>
-        /// <param name="id">Id of the entity to get, must be marked with [Key] attribute</param>
+        /// <param name="keyObject">Single or composite Key object that represents the entity to get</param>
         /// <param name="transaction">The transaction to run under, null (the default) if none</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout</param>
         /// <returns>Entity of T</returns>
-        public static T Get<T>(this IDbConnection connection, dynamic id, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
+        public static T Get<T>(this IDbConnection connection, dynamic keyObject, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             var type = typeof(T);
-
-            if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
-            {
-                var key = GetSingleKey<T>(nameof(Get));
-                var name = GetTableName(type);
-
-                sql = $"select * from {name} where {key.Name} = @id";
-                GetQueries[type.TypeHandle] = sql;
-            }
-
-            var dynParams = new DynamicParameters();
-            dynParams.Add("@id", id);
+            List<PropertyInfo> keyProperties = GetAllKeys(type);
+            string sql = GenerateGetQuery(connection, type, keyProperties);
+            DynamicParameters dynParams = GenerateGetParams(type, keyObject, keyProperties);
 
             T obj;
 
@@ -236,7 +297,6 @@ namespace Dapper.Contrib.Extensions
 
             if (!GetQueries.TryGetValue(cacheType.TypeHandle, out string sql))
             {
-                GetSingleKey<T>(nameof(GetAll));
                 var name = GetTableName(type);
 
                 sql = "select * from " + name;
@@ -422,10 +482,7 @@ namespace Dapper.Contrib.Extensions
                 }
             }
 
-            var keyProperties = KeyPropertiesCache(type).ToList();  //added ToList() due to issue #418, must work on a list copy
-            var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
-            if (keyProperties.Count == 0 && explicitKeyProperties.Count == 0)
-                throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");
+            var keyProperties = GetAllKeys(type);
 
             var name = GetTableName(type);
 
@@ -433,7 +490,6 @@ namespace Dapper.Contrib.Extensions
             sb.AppendFormat("update {0} set ", name);
 
             var allProperties = TypePropertiesCache(type);
-            keyProperties.AddRange(explicitKeyProperties);
             var computedProperties = ComputedPropertiesCache(type);
             var nonIdProps = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
 
@@ -491,13 +547,9 @@ namespace Dapper.Contrib.Extensions
                 }
             }
 
-            var keyProperties = KeyPropertiesCache(type).ToList();  //added ToList() due to issue #418, must work on a list copy
-            var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
-            if (keyProperties.Count == 0 && explicitKeyProperties.Count == 0)
-                throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");
+            var keyProperties = GetAllKeys(type);
 
             var name = GetTableName(type);
-            keyProperties.AddRange(explicitKeyProperties);
 
             var sb = new StringBuilder();
             sb.AppendFormat("delete from {0} where ", name);

--- a/tests/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -136,6 +136,32 @@ namespace Dapper.Tests.Contrib
             }
         }
 
+
+        [Fact]
+        public async Task InsertGetUpdateDeleteWithCompositeKeyAsync()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                var guid1 = Guid.NewGuid().ToString();
+                var guid2 = Guid.NewGuid().ToString();
+                var thing1 = new Thing { FirstId = guid1, SecondId = guid2, Name = "Foo", Created = DateTime.Now };
+                var originalThingCount = (await connection.QueryAsync<int>("Select Count(*) From Things")).First();
+                await connection.InsertAsync(thing1);
+                var list1 = (await connection.QueryAsync<Thing>("select * from Things")).ToList();
+                Assert.Equal(list1.Count, originalThingCount + 1);
+                thing1 = await connection.GetAsync<Thing>(new { FirstId = guid1, SecondId = guid2 });
+                Assert.Equal(thing1.FirstId, guid1);
+                Assert.Equal(thing1.SecondId, guid2);
+                thing1.Name = "Bar";
+                await connection.UpdateAsync(thing1);
+                thing1 = await connection.GetAsync<Thing>(new { FirstId = guid1, SecondId = guid2 });
+                Assert.Equal("Bar", thing1.Name);
+                connection.Delete(thing1);
+                thing1 = await connection.GetAsync<Thing>(new { FirstId = guid1, SecondId = guid2 });
+                Assert.Null(thing1);
+            }
+        }
+
         [Fact]
         public async Task TableNameAsync()
         {

--- a/tests/Dapper.Tests.Contrib/TestSuites.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuites.cs
@@ -34,6 +34,8 @@ namespace Dapper.Tests.Contrib
                 // ReSharper disable once AccessToDisposedClosure
                 void dropTable(string name) => connection.Execute($"IF OBJECT_ID('{name}', 'U') IS NOT NULL DROP TABLE [{name}]; ");
                 connection.Open();
+                dropTable("Things");
+                connection.Execute("CREATE TABLE Things (FirstId nchar(36) not null, SecondId nchar(36) not null, Name nvarchar(100) not null, Created DateTime null, PRIMARY KEY (FirstId, SecondId));");
                 dropTable("Stuff");
                 connection.Execute("CREATE TABLE Stuff (TheId int IDENTITY(1,1) not null, Name nvarchar(100) not null, Created DateTime null);");
                 dropTable("People");
@@ -80,6 +82,8 @@ namespace Dapper.Tests.Contrib
                     // ReSharper disable once AccessToDisposedClosure
                     void dropTable(string name) => connection.Execute($"DROP TABLE IF EXISTS `{name}`;");
                     connection.Open();
+                    dropTable("Things");
+                    connection.Execute("CREATE TABLE Things (FirstId nvarchar(36) not null, SecondId nvarchar(36) not null, Name nvarchar(100) not null, Created DateTime null, PRIMARY KEY (FirstId, SecondId));");
                     dropTable("Stuff");
                     connection.Execute("CREATE TABLE Stuff (TheId int not null AUTO_INCREMENT PRIMARY KEY, Name nvarchar(100) not null, Created DateTime null);");
                     dropTable("People");
@@ -127,6 +131,7 @@ namespace Dapper.Tests.Contrib
             using (var connection = new SqliteConnection(ConnectionString))
             {
                 connection.Open();
+                connection.Execute("CREATE TABLE Things (FirstId nchar(36) not null, SecondId nchar(36) not null, Name nvarchar(100) not null, Created DateTime null, PRIMARY KEY (FirstId, SecondId));");
                 connection.Execute("CREATE TABLE Stuff (TheId integer primary key autoincrement not null, Name nvarchar(100) not null, Created DateTime null) ");
                 connection.Execute("CREATE TABLE People (Id integer primary key autoincrement not null, Name nvarchar(100) not null) ");
                 connection.Execute("CREATE TABLE Users (Id integer primary key autoincrement not null, Name nvarchar(100) not null, Age int not null) ");
@@ -160,6 +165,7 @@ namespace Dapper.Tests.Contrib
             using (var connection = new SqlCeConnection(ConnectionString))
             {
                 connection.Open();
+                connection.Execute(@"CREATE TABLE Things (FirstId nchar(36) not null, SecondId nchar(36) not null, Name nvarchar(100) not null, Created DateTime null, PRIMARY KEY (FirstId, SecondId));");
                 connection.Execute(@"CREATE TABLE Stuff (TheId int IDENTITY(1,1) not null, Name nvarchar(100) not null, Created DateTime null) ");
                 connection.Execute(@"CREATE TABLE People (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null) ");
                 connection.Execute(@"CREATE TABLE Users (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, Age int not null) ");


### PR DESCRIPTION
THIS IS A NEW VERSION OF A VERY OLD AND FORGOTTEN PULL REQUEST ( #636).
PLEASE REVIEW IT WITH LOVE. 🥰

Hello guys.

I changed a bit the implementation of the Get method so it can also work with composite keys. I have a few tables with this design and it always annoyed me the fact that Update, Insert and Delete supported them but I had to write custom queries when I wanted to retrieve records from database.

The method still works the same way it was defined before.

`var regularKey = connection.Get<RegularKey>(1);`

But now also supports operations like this:

```
var keytest11 = connection.Get<KeyTest>(new KeyTest { Id1 = 1, Id2 = 2 });
var keytest12 = connection.Get<KeyTest>(new { id1 = 1, id2 = 2 });
var keytest21 = connection.Get<KeyTest>(new { Id1 = 2, Id2 = 1 });

var singleKey1 = connection.Get<SingleKey>(1);
var singleKey2 = connection.Get<SingleKey>(new { myKey = 2 });
```

I was also able to optimize Update and Delete methods a bit by using a new method to retrieve all keys.

For your appreciation and code review.

Cheers