### PR TITLE
allow AddClause to be overridden

### DIFF
--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -102,7 +102,7 @@ namespace Dapper
         public Template AddTemplate(string sql, dynamic parameters = null) =>
             new Template(this, sql, parameters);
 
-        protected SqlBuilder AddClause(string name, string sql, object parameters, string joiner, string prefix = "", string postfix = "", bool isInclusive = false)
+        protected virtual SqlBuilder AddClause(string name, string sql, object parameters, string joiner, string prefix = "", string postfix = "", bool isInclusive = false)
         {
             if (!_data.TryGetValue(name, out Clauses clauses))
             {


### PR DESCRIPTION
Currently `AddClause` is protected but it is not marked as virtual, and thus can't be overridden.

This simple change will allow further customization of the builder. Eg: ignoring clauses with empty parameters, empty sql, etc.