### PR TITLE
GetTemplateParameter method in DynamicParameters

### DIFF
--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -330,6 +330,39 @@ namespace Dapper
         }
 
         /// <summary>
+        /// Param names from templates
+        /// </summary>
+        public IEnumerable<string> TemplateParameterNames => templates.Select(t => t.GetType().GetProperties().Select(p => p.Name)).SelectMany(p => p);
+
+        /// <summary>
+        /// Get the value of a parameter that was created from a template
+        /// </summary>
+        /// <typeparam name="T">The type of a parameter</typeparam>
+        /// <param name="name"></param>
+        /// <returns>The value of the parameter</returns>
+        /// <exception cref="Exception">When templates is null or the param wasn't found</exception>
+        public T GetTemplateParameter<T>(string name)
+        {
+            if (templates == null)
+                throw new Exception("There are no templates");
+
+            foreach (object t in templates)
+            {
+                var property = t.GetType().GetProperties().Where(p => p.Name == name).FirstOrDefault();
+
+                if (property != null)
+                    return (T)property.GetValue(t);
+            }
+
+            throw new Exception($"Parameter name {name} not present in templates");
+        }
+
+        /// <summary>
+        /// Param names from templates and bag
+        /// </summary>
+        public IEnumerable<string> AllParameterNames => ParameterNames.Concat(TemplateParameterNames);
+
+        /// <summary>
         /// Allows you to automatically populate a target property/field from output parameters. It actually
         /// creates an InputOutput parameter, so you can still pass data in.
         /// </summary>

--- a/tests/Dapper.Tests/ParameterTests.cs
+++ b/tests/Dapper.Tests/ParameterTests.cs
@@ -1593,5 +1593,29 @@ select @hits as [Hits], (@count - @misses) as [Misses], @query as [Query];
             if (delta != 0) blocks++;
             return blocks * padFactor;
         }
+
+        [Fact]
+        public void TestGetParameterFromAnonymousType()
+        {
+            // https://github.com/DapperLib/Dapper/issues/343
+            // https://github.com/DapperLib/Dapper/issues/1113
+
+            var parameters = new DynamicParameters(new { par = 1 });
+
+            Assert.Equal(1, parameters.GetTemplateParameter<int>("par"));
+            Assert.Equal("par", parameters.TemplateParameterNames.First());
+        }
+
+        [Fact]
+        public void TestGetAllParemeters()
+        {
+            var parameters = new DynamicParameters(new { par1 = 1 });
+            parameters.Add("par2", 2);
+
+            var paramNames = parameters.AllParameterNames.ToList();
+
+            Assert.Equal("par2", paramNames[0]);
+            Assert.Equal("par1", paramNames[1]);
+        }
     }
 }


### PR DESCRIPTION
This pr is a proposition to resolve this problem
```csharp
var parameters = DynamicParameters(new { p1 = 1)};
parameters.Get<int>("p1"); // KeyNotFoundException
```
I suppose, now there is no way to get a parameter value/name from an anonymous type

Some related issues #343, #1113

P.S. I've tried to change `Get` method, but tests fail then