### PR TITLE
fix(TypeHandler): use the custom type handler when packing a list parameter

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2168,6 +2168,7 @@ namespace Dapper
                 if (list is not null && !viaSplit)
                 {
                     object? lastValue = null;
+                    SqlMapper.ITypeHandler? handler = null;
                     foreach (var item in list)
                     {
                         if (++count == 1) // first item: fetch some type info
@@ -2178,7 +2179,7 @@ namespace Dapper
                             }
                             if (!isDbString)
                             {
-                                dbType = LookupDbType(item.GetType(), "", true, out var handler);
+                                dbType = LookupDbType(item.GetType(), "", true, out handler);
                             }
                         }
                         var nextName = namePrefix + count.ToString();
@@ -2199,14 +2200,23 @@ namespace Dapper
                                 }
                             }
 
-                            var tmp = listParam.Value = SanitizeParameterValue(item);
-                            if (tmp is not null && tmp is not DBNull)
-                                lastValue = tmp; // only interested in non-trivial values for padding
-
-                            if (DynamicParameters.ShouldSetDbType(dbType) && listParam.DbType != dbType.GetValueOrDefault())
+                            if (handler is null)
                             {
-                                listParam.DbType = dbType.GetValueOrDefault();
+                                var tmp = listParam.Value = SanitizeParameterValue(item);
+                                if (tmp is not null && tmp is not DBNull)
+                                    lastValue = tmp; // only interested in non-trivial values for padding
+
+                                if (DynamicParameters.ShouldSetDbType(dbType) && listParam.DbType != dbType.GetValueOrDefault())
+                                {
+                                    listParam.DbType = dbType.GetValueOrDefault();
+                                }
                             }
+                            else
+                            {
+                                if (DynamicParameters.ShouldSetDbType(dbType)) listParam.DbType = dbType.GetValueOrDefault();
+                                handler.SetValue(listParam, item ?? DBNull.Value);
+                            }
+
                             command.Parameters.Add(listParam);
                         }
                     }

--- a/tests/Dapper.Tests/TypeHandlerTests.cs
+++ b/tests/Dapper.Tests/TypeHandlerTests.cs
@@ -425,6 +425,24 @@ namespace Dapper.Tests
             Assert.Equal(200, foo.Value);
         }
 
+        [Fact]
+        public void Issue2067_TestCustomValueCollection()
+        {
+            SqlMapper.AddTypeHandler(RatingValueHandler.Default);
+
+            var parameters = new
+            {
+                ListOfRatingValues = new List<RatingValue>
+                {
+                    new() { Value = 1 },
+                    new() { Value = 2 },
+                }
+            };
+
+            var result = connection.Query<int>("SELECT 1 WHERE 1 IN @ListOfRatingValues", parameters).Single();
+            Assert.Equal(1, result);
+        }
+
         public class StringListTypeHandler : SqlMapper.TypeHandler<List<string>>
         {
             private StringListTypeHandler()


### PR DESCRIPTION
Fixes #2067

The code for `SqlMapper.PackListParameters` was not using the custom type handler. This caused an error like `No mapping exists from object type xxxxx to a known managed provider native type.` when passing a collection parameter to a query, when the type of the collection items is not natively supported by the SQL client, and when a custom `TypeHandler` is registered for it.

Here this is fixed by using the same logic that is already in `DynamicParameters.AddParameter`.

A unit test is added to cover the scenario.