### PR TITLE
🐛 [QueryAsync] `NoCache` flag ignored when doing MultiMap

### DIFF
--- a/tests/Dapper.Tests/AsyncTests.cs
+++ b/tests/Dapper.Tests/AsyncTests.cs
@@ -1013,5 +1013,24 @@ SET @AddressPersonId = @PersonId", p).ConfigureAwait(false))
             await MarsConnection.QueryAsync<int, int, (int, int)>(cmdDef, splitOn: "b", map: (a, b) => (a, b));
             Assert.Equal(0, SqlMapper.GetCachedSQLCount());
         }
+
+
+        [Fact]
+        public async Task AssertNoCacheWorksForQueryAsync()
+        {
+            const int a = 123, b = 456;
+            var cmdDef = new CommandDefinition("select @a as a, @b as b;", new
+            {
+                a,
+                b
+            }, commandType: CommandType.Text, flags: CommandFlags.NoCache | CommandFlags.Buffered);
+
+            SqlMapper.PurgeQueryCache();
+            var before = SqlMapper.GetCachedSQLCount();
+            Assert.Equal(0, before);
+
+            await MarsConnection.QueryAsync<(int, int)>(cmdDef);
+            Assert.Equal(0, SqlMapper.GetCachedSQLCount());
+        }
     }
 }


### PR DESCRIPTION
As the `AssertNoCacheWorksForMultiMap` tests shows, when the `QueryAsync` method is passed a `splitOn` and `map` arguments, the `NoCache` flag is actually ignored.

The issue seems to come from [here](https://github.com/DapperLib/Dapper/blob/main/Dapper/SqlMapper.Async.cs#L942)