### PR TITLE
Fix and clarify OrWhere caveats in SqlBuilder docs

### DIFF
--- a/Dapper.SqlBuilder/Readme.md
+++ b/Dapper.SqlBuilder/Readme.md
@@ -85,10 +85,13 @@ var count = conn.ExecuteScalar<int>(countTemplate.RawSql, countTemplate.Paramete
 Limitations and caveats
 --------
 
-OrWhere use `and` not `or` to concat sql problem
+### Combining the Where and OrWhere methods
 
-[Issue 647](https://github.com/DapperLib/Dapper/issues/647) 
+The OrWhere method currently groups all `and` and `or` clauses by type,
+which may result in possibly unexpected outcomes.
+See also [issue 647](https://github.com/DapperLib/Dapper/issues/647).
 
+For example, when providing the following clauses
 ```csharp
 sql.Where("a = @a1");
 sql.OrWhere("b = @b1");
@@ -97,11 +100,11 @@ sql.OrWhere("b = @b2");
 ```
 
 SqlBuilder will generate sql
-```sql=
-a = @a1 AND b = @b1 AND a = @a2 AND b = @b2
+```sql
+a = @a1 AND a = @a2 AND ( b = @b1 OR b = @b2 )
 ```
 
-not
+and not say
 ```sql
 a = @a1 OR b = @b1 AND a = @a2 OR b = @b2
 ```

--- a/Dapper.SqlBuilder/Readme.md
+++ b/Dapper.SqlBuilder/Readme.md
@@ -88,10 +88,13 @@ Limitations and caveats
 ### Combining the Where and OrWhere methods
 
 The OrWhere method currently groups all `and` and `or` clauses by type,
-which may result in possibly unexpected outcomes.
+then join the groups with `and` or `or` depending on the first call.
+This may result in possibly unexpected outcomes.
 See also [issue 647](https://github.com/DapperLib/Dapper/issues/647).
 
-For example, when providing the following clauses
+#### Example Where first
+
+When providing the following clauses
 ```csharp
 sql.Where("a = @a1");
 sql.OrWhere("b = @b1");
@@ -107,4 +110,19 @@ a = @a1 AND a = @a2 AND ( b = @b1 OR b = @b2 )
 and not say
 ```sql
 a = @a1 OR b = @b1 AND a = @a2 OR b = @b2
+```
+
+#### Example OrWhere first
+
+When providing the following clauses
+```csharp
+sql.OrWhere("b = @b1");
+sql.Where("a = @a1");
+sql.OrWhere("b = @b2");
+sql.Where("a = @a2");
+```
+
+SqlBuilder will generate sql
+```sql
+a = @a1 OR a = @a2 OR ( b = @b1 OR b = @b2 )
 ```


### PR DESCRIPTION
When looking into documentation of the `SqlBuilder` about combining `Where` and `OrWhere`, followed by reading up on it on #647, I noticed the behavior described in the readme differs from the behavior I'm currently observing (and which is also observed in #647).

This PR updates the documentation example to match with current observed behavior and also adds some additional wording for better readability.