### PR TITLE
performance: skip `ToString` with interpolated string

### DIFF
--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -407,7 +407,7 @@ namespace Dapper
             if (setter is not null) goto MAKECALLBACK;
 
             // Come on let's build a method, let's build it, let's build it now!
-            var dm = new DynamicMethod("ExpressionParam" + Guid.NewGuid().ToString(), null, new[] { typeof(object), GetType() }, true);
+            var dm = new DynamicMethod($"ExpressionParam{Guid.NewGuid()}", null, new[] { typeof(object), GetType() }, true);
             var il = dm.GetILGenerator();
 
             il.Emit(OpCodes.Ldarg_0); // [object]

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2565,7 +2565,7 @@ namespace Dapper
                 filterParams = !CompiledRegex.LegacyParameter.IsMatch(identity.Sql);
             }
             
-            var dm = new DynamicMethod("ParamInfo" + Guid.NewGuid().ToString(), null, [typeof(IDbCommand), typeof(object)], type, true);
+            var dm = new DynamicMethod($"ParamInfo{Guid.NewGuid()}", null, [typeof(IDbCommand), typeof(object)], type, true);
 
             var il = dm.GetILGenerator();
 
@@ -3321,7 +3321,7 @@ namespace Dapper
             }
 
             var returnType = type.IsValueType ? typeof(object) : type;
-            var dm = new DynamicMethod("Deserialize" + Guid.NewGuid().ToString(), returnType, [typeof(DbDataReader)], type, true);
+            var dm = new DynamicMethod($"Deserialize{Guid.NewGuid()}", returnType, [typeof(DbDataReader)], type, true);
             var il = dm.GetILGenerator();
 
             if (IsValueTuple(type))


### PR DESCRIPTION
Interpolated string skips the `Guid.ToString` allocation by calling `ISpanFormattable.TryFormat`