### PR TITLE
Add CommandDefinition.SetCommandSetup for configuring commands after Dapper setup

### DIFF
--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -16,6 +16,17 @@ namespace Dapper
             return new CommandDefinition(parameters is DynamicParameters ? parameters : null, flags);
         }
 
+        /// <summary>
+        /// Register a global callback to configure commands after Dapper has performed its own setup.
+        /// Useful for setting provider-specific properties like SqlCommand.RetryLogicProvider.
+        /// Pass null to remove any previously registered callback.
+        /// </summary>
+        /// <param name="setup">The callback to invoke after command setup, or null to clear.</param>
+        public static void SetCommandSetup(Action<IDbCommand>? setup)
+        {
+            commandSetup = setup;
+        }
+
         internal void OnCompleted()
         {
             (Parameters as SqlMapper.IParameterCallbacks)?.OnCompleted();
@@ -136,10 +147,13 @@ namespace Dapper
             }
             cmd.CommandType = CommandTypeDirect;
             paramReader?.Invoke(cmd, Parameters);
+            commandSetup?.Invoke(cmd);
             return cmd;
         }
 
         private static SqlMapper.Link<Type, Action<IDbCommand>>? commandInitCache;
+
+        private static Action<IDbCommand>? commandSetup;
 
         internal static void ResetCommandInitCache()
             => SqlMapper.Link<Type, Action<IDbCommand>>.Clear(ref commandInitCache);

--- a/Dapper/PublicAPI/net461/PublicAPI.Unshipped.txt
+++ b/Dapper/PublicAPI/net461/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+static Dapper.CommandDefinition.SetCommandSetup(System.Action<System.Data.IDbCommand>? setup) -> void

--- a/Dapper/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/Dapper/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+static Dapper.CommandDefinition.SetCommandSetup(System.Action<System.Data.IDbCommand>? setup) -> void

--- a/Dapper/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/Dapper/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+static Dapper.CommandDefinition.SetCommandSetup(System.Action<System.Data.IDbCommand>? setup) -> void


### PR DESCRIPTION
This PR adds a simple, non-invasive extension point to configure `IDbCommand` instances after Dapper has completed its own setup.

### Motivation

Applications communicating with cloud services need to handle transient faults. Microsoft.Data.SqlClient provides built-in [Configurable retry logic](https://learn.microsoft.com/en-us/sql/connect/ado-net/configurable-retry-logic), but while retry logic can be configured at the connection level (for `Open()` etc.), command-level retry requires setting `SqlCommand.RetryLogicProvider` on each command.

The current version of Dapper doesn't provide a way to configure provider-specific command properties like `RetryLogicProvider`.

### Solution

This PR adds a minimal API:

```csharp
public static void SetCommandSetup(Action<IDbCommand>? setup)
```

The callback is invoked at the end of internal SetupCommand, after Dapper has configured the command.

### Usage example

```csharp
// Configure once at application startup
var retryProvider = SqlConfigurableRetryFactory.CreateExponentialRetryProvider(new SqlRetryLogicOption());

CommandDefinition.SetCommandSetup(cmd =>
{
    if (cmd is SqlCommand sqlCmd)
        sqlCmd.RetryLogicProvider = retryProvider;
});

// All subsequent Dapper calls will have retry logic configured
connection.Query<int>("SELECT 1");
```

### Why this approach?

- Minimal API surface - Single static method, follows existing patterns like SqlMapper.SetTypeMap
- Non-invasive - No changes to CommandDefinition constructor or public properties
- Database-agnostic - Dapper remains provider-independent; the callback handles provider-specific logic
- Zero overhead when not used - Simple null check

### Related issues

- Addresses use case in #1864 (Support for SqlRetryLogic)
- Related to #2128 (alternative approach - custom command creation vs. post-setup configuration)