### PR TITLE
Add user buffer for QueryAsync

### DIFF
--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Data;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -20,6 +21,8 @@ namespace Dapper
         {
             (Parameters as SqlMapper.IParameterCallbacks)?.OnCompleted();
         }
+
+        public IList? Buffer { get; }
 
         /// <summary>
         /// The command (sql or a stored-procedure name) to execute
@@ -83,7 +86,7 @@ namespace Dapper
         /// <param name="cancellationToken">The cancellation token for this command.</param>
         public CommandDefinition(string commandText, object? parameters = null, IDbTransaction? transaction = null, int? commandTimeout = null,
                                  CommandType? commandType = null, CommandFlags flags = CommandFlags.Buffered
-                                 , CancellationToken cancellationToken = default
+                                 , CancellationToken cancellationToken = default, IList? buffer = null
             )
         {
             CommandText = commandText;
@@ -93,6 +96,7 @@ namespace Dapper
             CommandTypeDirect = commandType ?? InferCommandType(commandText);
             Flags = flags;
             CancellationToken = cancellationToken;
+            Buffer = buffer;
         }
 
         internal static CommandType InferCommandType(string sql)

--- a/Dapper/PublicAPI.Shipped.txt
+++ b/Dapper/PublicAPI.Shipped.txt
@@ -10,6 +10,7 @@ Dapper.CommandDefinition.CancellationToken.get -> System.Threading.CancellationT
 Dapper.CommandDefinition.CommandDefinition() -> void
 Dapper.CommandDefinition.CommandDefinition(string! commandText, object? parameters = null, System.Data.IDbTransaction? transaction = null, int? commandTimeout = null, System.Data.CommandType? commandType = null, Dapper.CommandFlags flags = Dapper.CommandFlags.Buffered, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 Dapper.CommandDefinition.CommandText.get -> string!
+Dapper.CommandDefinition.Buffer.get -> IEnumerable?
 Dapper.CommandDefinition.CommandTimeout.get -> int?
 Dapper.CommandDefinition.CommandType.get -> System.Data.CommandType?
 Dapper.CommandDefinition.Flags.get -> Dapper.CommandFlags

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -447,7 +447,7 @@ namespace Dapper
 
                 if (command.Buffered)
                 {
-                    var buffer = new List<T>();
+                    var buffer = command.Buffer as IList<T> ?? new List<T>();
                     var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
                     while (await reader.ReadAsync(cancel).ConfigureAwait(false))
                     {
@@ -473,6 +473,8 @@ namespace Dapper
                 if (wasClosed) cnn.Close();
             }
         }
+        
+        private 
 
         private static async Task<T> QueryRowAsync<T>(this IDbConnection cnn, Row row, Type effectiveType, CommandDefinition command)
         {

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -474,7 +474,6 @@ namespace Dapper
             }
         }
         
-        private 
 
         private static async Task<T> QueryRowAsync<T>(this IDbConnection cnn, Row row, Type effectiveType, CommandDefinition command)
         {


### PR DESCRIPTION
I suggest adding the ability to pass a custom buffer from user code. This would make it possible, in flows where we sequentially iterate over a large table and process records in chunks, to avoid reallocating the buffer. In my case, I need to traverse 5 million rows in batches of 100k when retrieving them from the database. I want to do this using a single array instead of allocating a new one each time.

Why is this not equivalent to a buffering flag?
Because the method returns IEnumerable rather than IAsyncEnumerable. As a result, the non-buffered mode relies on synchronous overloads. We should either change the design accordingly or provide an IAsyncEnumerable counterpart for the method without the buffering flag.