### PR TITLE
Fix segfault when ICustomQueryParameter is a value type (#2189)

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2666,7 +2666,11 @@ namespace Dapper
                 {
                     il.Emit(OpCodes.Ldloc, typedParameterLocal); // stack is now [parameters] [typed-param]
                     il.Emit(callOpCode, prop.GetGetMethod()!); // stack is [parameters] [custom]
-                    if (!prop.PropertyType.IsValueType)
+                    if (prop.PropertyType.IsValueType)
+                    {
+                        il.Emit(OpCodes.Box, prop.PropertyType); // stack is [parameters] [boxed-custom]
+                    }
+                    else
                     {
                         // throw if null
                         var notNull = il.DefineLabel();
@@ -2678,7 +2682,7 @@ namespace Dapper
                     }
                     il.Emit(OpCodes.Ldarg_0); // stack is now [parameters] [custom] [command]
                     il.Emit(OpCodes.Ldstr, prop.Name); // stack is now [parameters] [custom] [command] [name]
-                    il.EmitCall(OpCodes.Callvirt, prop.PropertyType.GetMethod(nameof(ICustomQueryParameter.AddParameter))!, null); // stack is now [parameters]
+                    il.EmitCall(OpCodes.Callvirt, typeof(ICustomQueryParameter).GetMethod(nameof(ICustomQueryParameter.AddParameter))!, null); // stack is now [parameters]
                     continue;
                 }
 #pragma warning disable 618

--- a/tests/Dapper.Tests/ParameterTests.cs
+++ b/tests/Dapper.Tests/ParameterTests.cs
@@ -61,6 +61,21 @@ namespace Dapper.Tests
             }
         }
 
+        public readonly struct DbCustomParamStruct : SqlMapper.ICustomQueryParameter
+        {
+            private readonly IDbDataParameter _sqlParameter;
+
+            public DbCustomParamStruct(IDbDataParameter sqlParameter)
+            {
+                _sqlParameter = sqlParameter;
+            }
+
+            public void AddParameter(IDbCommand command, string name)
+            {
+                command.Parameters.Add(_sqlParameter);
+            }
+        }
+
         private static IEnumerable<IDataRecord> CreateSqlDataRecordList(IDbCommand command, IEnumerable<int> numbers)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -885,8 +900,23 @@ namespace Dapper.Tests
             Assert.Equal(123, result2.Foo);
             Assert.Equal("abc", result2.Bar);
         }
-        
-        
+
+        [Fact]
+        public void TestCustomParameterValueType()
+        {
+            // Value type (struct) ICustomQueryParameter previously caused a segfault
+            // because the IL emitted Callvirt on an unboxed struct (see #2189)
+            var args = new {
+                foo = new DbCustomParamStruct(Provider.CreateRawParameter("foo", 123)),
+                bar = "abc"
+            };
+            var result = connection.Query("select Foo=@foo, Bar=@bar", args).Single();
+            int foo = result.Foo;
+            string bar = result.Bar;
+            Assert.Equal(123, foo);
+            Assert.Equal("abc", bar);
+        }
+
         [Fact]
         public void TestDynamicParamNullSupport()
         {


### PR DESCRIPTION
The IL emitted by CreateParamInfoGenerator used Callvirt to invoke AddParameter on an unboxed struct sitting on the evaluation stack. Callvirt expects a reference, so the CLR misinterpreted the raw struct bytes as an object pointer, causing a fatal CLR error (0x80131506). Fixes #2189 