### PR TITLE
fix: pass IParameterCallbacks to GridReader for QueryMultiple

### DIFF
--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -1042,7 +1042,7 @@ namespace Dapper
                 cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
                 reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess, command.CancellationToken).ConfigureAwait(false);
 
-                var result = new GridReader(cmd, reader, identity, command.Parameters as DynamicParameters, command.AddToCache, command.CancellationToken);
+                var result = new GridReader(cmd, reader, identity, command.Parameters as IParameterCallbacks, command.AddToCache, command.CancellationToken);
                 wasClosed = false; // *if* the connection was closed and we got this far, then we now have a reader
                 // with the CloseConnection flag, so the reader will deal with the connection; we
                 // still need something in the "finally" to ensure that broken SQL still results

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1155,7 +1155,7 @@ namespace Dapper
                 cmd = command.SetupCommand(cnn, info.ParamReader);
                 reader = ExecuteReaderWithFlagsFallback(cmd, wasClosed, CommandBehavior.SequentialAccess);
 
-                var result = new GridReader(cmd, reader, identity, command.Parameters as DynamicParameters, command.AddToCache);
+                var result = new GridReader(cmd, reader, identity, command.Parameters as IParameterCallbacks, command.AddToCache);
                 cmd = null; // now owned by result
                 wasClosed = false; // *if* the connection was closed and we got this far, then we now have a reader
                 // with the CloseConnection flag, so the reader will deal with the connection; we


### PR DESCRIPTION
## Summary

- Cast `command.Parameters` to `IParameterCallbacks` (not `DynamicParameters`) when creating `GridReader` in sync and async `QueryMultiple` paths.

## Motivation

Fixes #2179 — custom `IParameterCallbacks` implementations were ignored because only `DynamicParameters` was passed through, even though `GridReader` already accepts `IParameterCallbacks`.

## Test plan

- [ ] Existing `QueryMultiple` / async grid reader tests in `tests/Dapper.Tests`