### PR TITLE
fix: skip Cancel in QueryUnbufferedAsync when reader is drained (#2188)

### DIFF
--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -1301,6 +1301,7 @@ namespace Dapper
                 bool wasClosed = cnn.State == ConnectionState.Closed;
                 using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
                 DbDataReader? reader = null;
+                bool readerDrained = false;
                 try
                 {
                     if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
@@ -1312,6 +1313,7 @@ namespace Dapper
                     {
                         if (reader.FieldCount == 0)
                         {
+                            readerDrained = true;
                             yield break;
                         }
                         tuple = info.Deserializer = new DeserializerState(hash, GetDeserializer(effectiveType, reader, 0, -1, false));
@@ -1327,13 +1329,14 @@ namespace Dapper
                         yield return GetValue<T>(reader, effectiveType, val);
                     }
                     while (await reader.NextResultAsync(cancel).ConfigureAwait(false)) { /* ignore subsequent result sets */ }
+                    readerDrained = true;
                     command.OnCompleted();
                 }
                 finally
                 {
                     if (reader is not null)
                     {
-                        if (!reader.IsClosed)
+                        if (!readerDrained && !reader.IsClosed)
                         {
                             try { cmd?.Cancel(); }
                             catch { /* don't spoil any existing exception */ }


### PR DESCRIPTION
## Summary

- Track whether `QueryUnbufferedAsync` finished reading all rows and result sets (`readerDrained`).
- Only call `cmd.Cancel()` in the `finally` block when the reader was **not** fully drained and is still open.

This avoids unnecessary command cancellation on providers such as Npgsql where `DbDataReader.IsClosed` remains `false` after the result set is fully consumed, which was causing extra connection churn and server-side cancel overhead.

## Test plan

- [ ] Existing `TestBasicStringUsageUnbufferedAsync` / cancellation tests (CI)
- [ ] With Npgsql: run `QueryUnbufferedAsync` to completion and confirm no `CANCEL` is issued in PostgreSQL logs

CI not run locally (no .NET SDK in contributor environment).

Fixes #2188