### PR TITLE
feat: Query with CommandDefinition and Type[] multi-map

### DIFF
--- a/Dapper/PublicAPI.Unshipped.txt
+++ b/Dapper/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 ﻿#nullable enable
 static Dapper.SqlMapper.Settings.PreferTypeHandlersForEnums.get -> bool
 static Dapper.SqlMapper.Settings.PreferTypeHandlersForEnums.set -> void
+static Dapper.SqlMapper.Query<TReturn>(this System.Data.IDbConnection! cnn, Dapper.CommandDefinition command, System.Type![]! types, System.Func<object![]!, TReturn>! map, string! splitOn = "Id") -> System.Collections.Generic.IEnumerable<TReturn>!

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1230,7 +1230,6 @@ namespace Dapper
                 }
 
                 var func = tuple.Func;
-                var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
                 while (reader.Read())
                 {
                     object? val = func(reader);
@@ -1548,6 +1547,23 @@ namespace Dapper
         [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Grandfathered")]
         public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, object? param = null, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMap<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(cnn, sql, map, param, transaction, buffered, splitOn, commandTimeout, commandType);
+
+        /// <summary>
+        /// Perform a multi-mapping query with an arbitrary number of input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="command">The command used to execute the query.</param>
+        /// <param name="types">Array of types in the recordset.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
+        public static IEnumerable<TReturn> Query<TReturn>(this IDbConnection cnn, CommandDefinition command, Type[] types, Func<object[], TReturn> map, string splitOn = "Id")
+        {
+            var results = MultiMapImpl(cnn, command, types, map, splitOn, null, null, true);
+            return command.Buffered ? results.ToList() : results;
+        }
 
         /// <summary>
         /// Perform a multi-mapping query with an arbitrary number of input types.

--- a/tests/Dapper.Tests/MultiMapTests.cs
+++ b/tests/Dapper.Tests/MultiMapTests.cs
@@ -491,6 +491,52 @@ Order by p.Id";
         }
 
         [Fact]
+        public void TestMultiMapArbitraryMapsCommandDefinition()
+        {
+            const string createSql = @"
+                create table #ReviewBoards (Id int, Name varchar(20), User1Id int, User2Id int, User3Id int, User4Id int, User5Id int, User6Id int, User7Id int, User8Id int, User9Id int)
+                create table #Users (Id int, Name varchar(20))
+
+                insert #Users values(9, 'User 9')
+                insert #ReviewBoards values(1, 'Review Board 1', 9, 9, 9, 9, 9, 9, 9, 9, 9)
+";
+            connection.Execute(createSql);
+            try
+            {
+                const string sql = @"
+                    select rb.Id, rb.Name, u1.*, u2.*, u3.*, u4.*, u5.*, u6.*, u7.*, u8.*, u9.*
+                    from #ReviewBoards rb
+                        inner join #Users u1 on u1.Id = rb.User1Id
+                        inner join #Users u2 on u2.Id = rb.User2Id
+                        inner join #Users u3 on u3.Id = rb.User3Id
+                        inner join #Users u4 on u4.Id = rb.User4Id
+                        inner join #Users u5 on u5.Id = rb.User5Id
+                        inner join #Users u6 on u6.Id = rb.User6Id
+                        inner join #Users u7 on u7.Id = rb.User7Id
+                        inner join #Users u8 on u8.Id = rb.User8Id
+                        inner join #Users u9 on u9.Id = rb.User9Id";
+
+                var types = new[] { typeof(ReviewBoard), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User) };
+                Func<object[], ReviewBoard> mapper = objects =>
+                {
+                    var board = (ReviewBoard)objects[0];
+                    board.User9 = (User)objects[9];
+                    return board;
+                };
+
+                var command = new CommandDefinition(sql);
+                var data = connection.Query<ReviewBoard>(command, types, mapper).ToList();
+
+                Assert.Equal(1, data.Count);
+                Assert.Equal("User 9", data[0].User9!.Name);
+            }
+            finally
+            {
+                connection.Execute("drop table #Users drop table #ReviewBoards");
+            }
+        }
+
+        [Fact]
         public void TestMultiMapGridReader()
         {
             const string createSql = @"


### PR DESCRIPTION
## Summary

Adds `Query<TReturn>(IDbConnection, CommandDefinition, Type[], Func<object[], TReturn>, splitOn)` for synchronous multi-map queries with more than seven types.

Forwards to the existing `MultiMapImpl` implementation (same pattern as the `string sql` overload).

Related to #2193; complements #2209 (async overload).

## Test plan

- [x] `TestMultiMapArbitraryMapsCommandDefinition`
- [ ] CI (no local .NET SDK in contributor environment)