### PR TITLE
Fixes QueryMultiple corrupting a later Query<T>'s DynamicParameters -- fixes #243, #2091

### DIFF
--- a/Dapper/SqlMapper.Identity.cs
+++ b/Dapper/SqlMapper.Identity.cs
@@ -94,16 +94,20 @@ namespace Dapper
             internal virtual Type GetType(int index) => throw new IndexOutOfRangeException(nameof(index));
 
 #pragma warning disable CS0618 // Type or member is obsolete
+            // Grid (multi-result) reads only build a deserializer and never bind parameters
+            // (parameters are bound once, against the command-level identity). Carrying parametersType
+            // here makes a grid-0 read of type T collide with a QueryAsync<T> identity and overwrite its
+            // ParamReader with a property-based reader (wrong for IDynamicParameters).
             internal Identity ForGrid<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(Type primaryType, int gridIndex) =>
-                new Identity<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(sql, commandType, connectionString, primaryType, parametersType, gridIndex);
+                new Identity<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(sql, commandType, connectionString, primaryType, null, gridIndex);
 
             internal Identity ForGrid(Type primaryType, int gridIndex) =>
-                new Identity(sql, commandType, connectionString, primaryType, parametersType, 0, gridIndex);
+                new Identity(sql, commandType, connectionString, primaryType, null, 0, gridIndex);
 
             internal Identity ForGrid(Type primaryType, Type[] otherTypes, int gridIndex) =>
                 (otherTypes is null || otherTypes.Length == 0)
-                ? new Identity(sql, commandType, connectionString, primaryType, parametersType, 0, gridIndex)
-                : new IdentityWithTypes(sql, commandType, connectionString, primaryType, parametersType, otherTypes, gridIndex);
+                ? new Identity(sql, commandType, connectionString, primaryType, null, 0, gridIndex)
+                : new IdentityWithTypes(sql, commandType, connectionString, primaryType, null, otherTypes, gridIndex);
 
             /// <summary>
             /// Create an identity for use with DynamicParameters, internal use only.

--- a/tests/Dapper.Tests/QueryMultipleTests.cs
+++ b/tests/Dapper.Tests/QueryMultipleTests.cs
@@ -30,6 +30,73 @@ namespace Dapper.Tests
             Assert.Equal(4, d.Single());
         }
 
+        // Regression for DapperLib/Dapper#243 and DapperLib/Dapper#2091:
+        // A QueryMultiple grid-read calls GetCacheInfo(identity, null), so for an IDynamicParameters
+        // parameter type it builds a property-based ParamReader (via CreateParamInfoGenerator) and
+        // caches it under an identity for grid 0 of type T which collides with the Query<T> identity.
+        // A subsequent Query<T> with DynamicParameters reuses that reader and sends no
+        // real parameters (manifesting as "must declare the scalar variable @x" /
+        // "@ParameterNames1 is not a parameter").
+        [Fact]
+        public void QueryMultipleThenQueryWithDynamicParameters_DoesNotDropParameters()
+        {
+            // two grids, same parameter
+            const string sql = "select @x as X; select @x as Y;"; 
+
+            var first = new DynamicParameters();
+            first.Add("x", 1);
+            using (var grid = connection.QueryMultiple(sql, first))
+            {
+                Assert.Equal(1, grid.Read<int>().Single());
+                Assert.Equal(1, grid.Read<int>().Single());
+            }
+
+            // Same sql + result type + DynamicParameters as grid 0 above; @x must still be supplied.
+            var second = new DynamicParameters();
+            second.Add("x", 42);
+            Assert.Equal(42, connection.Query<int>(sql, second).Single());
+        }
+
+        // Regression for DapperLib/Dapper#243 and DapperLib/Dapper#2091:
+        // The reverse order has always worked (Query<T> then QueryMultiple)
+        [Fact]
+        public void QueryThenQueryMultipleWithDynamicParameters_DoesNotDropParameters()
+        {
+            // distinct sql -> own cache entry (independent of the test above)
+            const string sql = "select @x as P; select @x as Q;";
+
+            var first = new DynamicParameters();
+            first.Add("x", 7);
+            Assert.Equal(7, connection.Query<int>(sql, first).Single());
+
+            var second = new DynamicParameters();
+            second.Add("x", 99);
+            using var grid = connection.QueryMultiple(sql, second);
+            Assert.Equal(99, grid.Read<int>().Single());
+            Assert.Equal(99, grid.Read<int>().Single());
+        }
+
+        // Stored-proc form of the same bug (#2091).        
+        [Fact]
+        public void QueryMultipleThenQueryStoredProc_DoesNotEmitDynamicParametersProperties()
+        {
+            connection.Execute("create proc #Repro2091 (@x int = 0, @z int = 0) as begin set nocount on; select @x as X; select @x as Y; end");
+
+            var first = new DynamicParameters();
+            first.Add("x", 1);
+            using (var grid = connection.QueryMultiple("#Repro2091", first, commandType: CommandType.StoredProcedure))
+            {
+                // grid 0 of <int> seeds the shared identity
+                Assert.Equal(1, grid.Read<int>().Single());
+                Assert.Equal(1, grid.Read<int>().Single());
+            }
+
+            var second = new DynamicParameters();
+            second.Add("x", 42);
+            // Without fix expect SqlException "@ParameterNames1 is not a parameter for procedure #Repro2091."
+            Assert.Equal(42, connection.Query<int>("#Repro2091", second, commandType: CommandType.StoredProcedure).Single());
+        }
+
         [Fact]
         public void TestMultiConversion()
         {


### PR DESCRIPTION
## Summary
Calling a query (stored proc or text) via `QueryMultiple(...).Read<T>()` and then via  `Query<T>(...)`/`QueryAsync<T>(...)` with **`DynamicParameters`** on the same SQL can cause the second call to send the **wrong parameters**, typically dropping them entirely. Depending on the target's signature this surfaces as:

- `Must declare the scalar variable "@x".` (text)
- `Procedure or function 'X' expects parameter '@y', which was not supplied.`
- `Procedure or function 'X' has too many arguments specified.`
- `@ParameterNames1 is not a parameter for procedure X.` (the literal symptom in #2091)

It's intermittent in real apps (depends on which call populates the shared cache entry first) and clears on app restart because the corruption lives in the process-wide query cache.

Fixes #243. Fixes #2091.

## Root cause
`Query<T>` and the first grid of a `QueryMultiple` over the same SQL share a single cache entry. A grid read only needs the deserializer and has no parameter instance, so it populates that shared entry with a null parameter
object. For `DynamicParameters` (whose real parameters live in an internal collection, not in the type's properties), Dapper then builds a parameter-reader from the type's *properties* (`ParameterNames`, `RemoveUnused`) that never emits the actual parameters. Because the grid identity still carries the parameter type, it collides with the `Query<T>` identity, so a later `Query<T>`
with `DynamicParameters` reuses that wrong reader and sends the wrong parameters (or none). Whichever call populates the entry first wins, which is why it's intermittent and clears on restart.

Anonymous/POCO parameters are unaffected since their parameters *are* their properties.

## Fix
`Identity.ForGrid(...)` now passes `null` for `parametersType` (grid reads never bind parameters).
This:
1. de-collides grid identities from `Query<T>` identities, so a `Query<T>` always builds/uses its own correct ParamReader; and
2. makes `GetCacheInfo` skip building a ParamReader for grid reads.

## Impact / trade-offs
- Parameter binding is unaffected for normal queries;  the command-level identity still carries `parametersType`.
- The grid-0 deserializer for `(sql, T)` is no longer shared with a `Query<T>` for the same `(sql, T)` so at most one extra deserializer compile (one-time, cached). **No per-call overhead.**
  Conversely, deserializers are now shared across *different* parameter types, which the old keying prevented (a small net win).
- A grid read can still share an entry with a **parameterless** `Query<T>(sql)` (both have `parametersType == null`); that's harmless as neither builds a ParamReader.

