### PR TITLE
[DRE-1706] - Resolve Intermittent ORA-01013 Errors After Migration from iBatis.Net to Dapper.Extensions

### DIFF
--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -5,7 +5,7 @@
     <PackageTags>orm;sql;micro-orm</PackageTags>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc. Major Sponsor: Dapper Plus from ZZZ Projects.</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -1053,13 +1053,6 @@ namespace Dapper
             {
                 if (reader is not null)
                 {
-                    if (!reader.IsClosed)
-                    {
-                        try { cmd?.Cancel(); }
-                        catch
-                        { /* don't spoil the existing exception */
-                        }
-                    }
                     reader.Dispose();
                 }
                 cmd?.Dispose();
@@ -1332,12 +1325,7 @@ namespace Dapper
                 finally
                 {
                     if (reader is not null)
-                    {
-                        if (!reader.IsClosed)
-                        {
-                            try { cmd?.Cancel(); }
-                            catch { /* don't spoil any existing exception */ }
-                        }
+                    {                        
 #if NET5_0_OR_GREATER
                         await reader.DisposeAsync();
 #else

--- a/Dapper/SqlMapper.GridReader.Async.cs
+++ b/Dapper/SqlMapper.GridReader.Async.cs
@@ -282,8 +282,7 @@ namespace Dapper
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
             {
                 if (reader is not null)
-                {
-                    if (!reader.IsClosed) Command?.Cancel();
+                {                    
 #if NET5_0_OR_GREATER
                     await reader.DisposeAsync();
 #else

--- a/Dapper/SqlMapper.GridReader.cs
+++ b/Dapper/SqlMapper.GridReader.cs
@@ -470,7 +470,6 @@ namespace Dapper
             {
                 if (reader is not null)
                 {
-                    if (!reader.IsClosed) Command?.Cancel();
                     reader.Dispose();
                     reader = null!;
                 }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1167,11 +1167,6 @@ namespace Dapper
             {
                 if (reader is not null)
                 {
-                    if (!reader.IsClosed)
-                    {
-                        try { cmd?.Cancel(); }
-                        catch { /* don't spoil any existing exception */ }
-                    }
                     reader.Dispose();
                 }
 
@@ -1248,11 +1243,6 @@ namespace Dapper
             {
                 if (reader is not null)
                 {
-                    if (!reader.IsClosed)
-                    {
-                        try { cmd?.Cancel(); }
-                        catch { /* don't spoil any existing exception */ }
-                    }
                     reader.Dispose();
                 }
                 if (wasClosed) cnn.Close();
@@ -1340,11 +1330,6 @@ namespace Dapper
             {
                 if (reader is not null)
                 {
-                    if (!reader.IsClosed)
-                    {
-                        try { cmd?.Cancel(); }
-                        catch { /* don't spoil any existing exception */ }
-                    }
                     reader.Dispose();
                 }
                 if (wasClosed) cnn.Close();


### PR DESCRIPTION
Following the migration of the DRE data access layer from [iBatis.Net](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=http%3A%2F%2FiBatis.Net.mcas.ms%3FMcasCtx%3D4%26McasTsid%3D20596&McasCSRF=5b3bf9618f7506a27de1aabd4f00270befc2772069094d6c3bf0b37a7eb3cfb8) (.NET 6) to Dapper.Extensions (.NET 10), the application is intermittently encountering Oracle error:

ORA-01013: user requested cancel of current operation

The issue is observed on a subset of SELECT queries and stored procedure executions. The same database operations executed successfully under the previous [iBatis.Net](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=http%3A%2F%2FiBatis.Net.mcas.ms%3FMcasCtx%3D4%26McasTsid%3D20596&McasCSRF=5b3bf9618f7506a27de1aabd4f00270befc2772069094d6c3bf0b37a7eb3cfb8) implementation.